### PR TITLE
Хованский Дмитрий. Лабораторная работа 3: Backend. Вариант 3.

### DIFF
--- a/.github/deadline.py
+++ b/.github/deadline.py
@@ -11,8 +11,8 @@ def main():
     deadline_date = {
         "lab:clang": datetime(2025, 3, 19, hour=19, tzinfo=moscow_tz),
         "lab:llvm ir": datetime(2025, 4, 9, hour=19, tzinfo=moscow_tz),
-        "lab:backend": datetime(2025, 6, 1, hour=19, tzinfo=moscow_tz),
-        "lab:mlir": datetime(2025, 6, 1, hour=19, tzinfo=moscow_tz),
+        "lab:backend": datetime(2025, 5, 8, hour=19, tzinfo=moscow_tz),
+        "lab:mlir": datetime(2025, 5, 21, hour=19, tzinfo=moscow_tz),
     }
 
     gh = Github(os.environ["GITHUB_TOKEN"])

--- a/llvm/compiler-course/backend/AddToCallPass-Mamaeva-Lab3/CMakeLists.txt
+++ b/llvm/compiler-course/backend/AddToCallPass-Mamaeva-Lab3/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "FMADecomposePass")
+set(Student "Mamaeva_Olga")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/AddToCallPass-Mamaeva-Lab3/FMADecomposePass.cpp
+++ b/llvm/compiler-course/backend/AddToCallPass-Mamaeva-Lab3/FMADecomposePass.cpp
@@ -1,0 +1,129 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "fma-decompose"
+
+using namespace llvm;
+
+namespace {
+
+class FMADecomposePass : public MachineFunctionPass {
+public:
+  static char ID;
+  FMADecomposePass() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    const X86Subtarget &ST = MF.getSubtarget<X86Subtarget>();
+    const X86InstrInfo *TII = ST.getInstrInfo();
+    MachineRegisterInfo &MRI = MF.getRegInfo();
+    bool Changed = false;
+
+    for (auto &MBB : MF) {
+      Changed |= processBasicBlock(MBB, TII, MRI);
+    }
+
+    return Changed;
+  }
+
+private:
+  bool processBasicBlock(MachineBasicBlock &MBB, const X86InstrInfo *TII,
+                         MachineRegisterInfo &MRI) {
+    bool Changed = false;
+    SmallVector<MachineInstr *, 8> ToErase;
+
+    for (auto &MI : MBB) {
+      if (!processInstruction(MI, MBB, TII, MRI, ToErase)) {
+        continue;
+      }
+      Changed = true;
+    }
+
+    for (auto *MI : ToErase) {
+      MI->eraseFromParent();
+    }
+
+    return Changed;
+  }
+
+  bool processInstruction(MachineInstr &MI, MachineBasicBlock &MBB,
+                          const X86InstrInfo *TII, MachineRegisterInfo &MRI,
+                          SmallVectorImpl<MachineInstr *> &ToErase) {
+    unsigned MulOpc, AddOpc;
+    if (!getFMADecompositionInfo(MI.getOpcode(), MulOpc, AddOpc)) {
+      return false;
+    }
+
+    decomposeFMAInstruction(MI, MBB, TII, MRI, MulOpc, AddOpc);
+    ToErase.push_back(&MI);
+    return true;
+  }
+
+  bool getFMADecompositionInfo(unsigned Opc, unsigned &MulOpc,
+                               unsigned &AddOpc) const {
+    switch (Opc) {
+    case X86::VFMADD132PSr:
+    case X86::VFMADD213PSr:
+    case X86::VFMADD231PSr:
+      MulOpc = X86::MULPSrr;
+      AddOpc = X86::ADDPSrr;
+      return true;
+    case X86::VFMADD132PDr:
+    case X86::VFMADD213PDr:
+    case X86::VFMADD231PDr:
+      MulOpc = X86::MULPDrr;
+      AddOpc = X86::ADDPDrr;
+      return true;
+    case X86::VFMADD132SSr:
+    case X86::VFMADD213SSr:
+    case X86::VFMADD231SSr:
+      MulOpc = X86::MULSSrr;
+      AddOpc = X86::ADDSSrr;
+      return true;
+    case X86::VFMADD132SDr:
+    case X86::VFMADD213SDr:
+    case X86::VFMADD231SDr:
+      MulOpc = X86::MULSDrr;
+      AddOpc = X86::ADDSDrr;
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  void decomposeFMAInstruction(MachineInstr &MI, MachineBasicBlock &MBB,
+                               const X86InstrInfo *TII,
+                               MachineRegisterInfo &MRI, unsigned MulOpc,
+                               unsigned AddOpc) {
+    Register Dst = MI.getOperand(0).getReg();
+    Register A = MI.getOperand(1).getReg();
+    Register B = MI.getOperand(2).getReg();
+    Register C = MI.getOperand(3).getReg();
+    DebugLoc DL = MI.getDebugLoc();
+
+    // Создаем временный регистр того же класса, что и операнды
+    const TargetRegisterClass *RC = MRI.getRegClass(A);
+    Register Tmp = MRI.createVirtualRegister(RC);
+
+    // Вставляем умножение перед оригинальной инструкцией
+    BuildMI(MBB, MI, DL, TII->get(MulOpc), Tmp).addReg(A).addReg(B);
+
+    // Вставляем сложение перед оригинальной инструкцией
+    BuildMI(MBB, MI, DL, TII->get(AddOpc), Dst).addReg(C).addReg(Tmp);
+  }
+
+  StringRef getPassName() const override { return "FMA Decomposition Pass"; }
+};
+
+char FMADecomposePass::ID = 0;
+
+} // namespace
+
+static RegisterPass<FMADecomposePass>
+    X("fma-decompose", "Decompose FMA instructions into MUL+ADD", false, false);

--- a/llvm/compiler-course/backend/chistov_a_combination/CMakeLists.txt
+++ b/llvm/compiler-course/backend/chistov_a_combination/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "CombinationPass")
+set(Student "Chistov_Alexey")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
+++ b/llvm/compiler-course/backend/chistov_a_combination/chistov_a_backend.cpp
@@ -1,0 +1,144 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/Passes/PassBuilder.h"
+#include <functional>
+
+namespace {
+class X86LogicOptPass : public llvm::MachineFunctionPass {
+private:
+  bool Changed = false;
+  const llvm::X86InstrInfo *TII;
+  const llvm::MachineRegisterInfo *MRI;
+
+  llvm::DenseMap<unsigned, unsigned> LogicToAVX = {
+      {llvm::X86::ANDPSrr, llvm::X86::VANDPSrr},
+      {llvm::X86::ORPSrr, llvm::X86::VORPSrr},
+      {llvm::X86::XORPSrr, llvm::X86::VXORPSrr},
+      {llvm::X86::PANDrr, llvm::X86::VPANDrr},
+      {llvm::X86::PORrr, llvm::X86::VPORrr},
+      {llvm::X86::PXORrr, llvm::X86::VPXORrr},
+      {llvm::X86::PANDNrr, llvm::X86::VPANDNrr},
+  };
+
+  using OptimizationPredicate = std::function<bool(llvm::MachineInstr &)>;
+  using OptimizationTransform =
+      std::function<void(llvm::MachineBasicBlock &, llvm::MachineInstr &,
+                         llvm::SmallVectorImpl<llvm::MachineInstr *> &)>;
+
+private: // auxiliary functions
+  void applyOptimizations(llvm::MachineFunction &MF,
+                          OptimizationPredicate shouldTransform,
+                          OptimizationTransform performTransform) {
+    for (auto &MBB : MF) {
+      llvm::SmallVector<llvm::MachineInstr *, 8> InstrsToRemove;
+      for (auto &MI : MBB) {
+        if (shouldTransform(MI)) {
+          performTransform(MBB, MI, InstrsToRemove);
+          Changed = true;
+        }
+      }
+      for (auto *I : InstrsToRemove)
+        I->eraseFromParent();
+    }
+  }
+
+  bool isLogicOpcode(unsigned Opcode) const {
+    return LogicToAVX.contains(Opcode);
+  }
+
+  unsigned getAVXOpcode(unsigned Opcode) const {
+    auto It = LogicToAVX.find(Opcode);
+    return It != LogicToAVX.end() ? It->second : 0;
+  }
+
+  void replaceWithAVX(llvm::MachineBasicBlock &MBB, llvm::MachineInstr &MI,
+                      llvm::SmallVectorImpl<llvm::MachineInstr *> &ToRemove) {
+    unsigned NewOpc = getAVXOpcode(MI.getOpcode());
+    if (!NewOpc)
+      return;
+
+    llvm::Register DestReg = MI.getOperand(0).getReg();
+    llvm::Register SrcReg1 = MI.getOperand(1).getReg();
+    llvm::Register SrcReg2 = MI.getOperand(2).getReg();
+
+    llvm::BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(NewOpc), DestReg)
+        .addReg(SrcReg1)
+        .addReg(SrcReg2);
+    ToRemove.push_back(&MI);
+    Changed = true;
+  }
+
+private: // optimizing passes
+  void optimizeLogicOperations(llvm::MachineFunction &MF) {
+    OptimizationPredicate shouldTransform = [&](llvm::MachineInstr &MI) {
+      return isLogicOpcode(MI.getOpcode());
+    };
+
+    OptimizationTransform transformInstr =
+        [&](llvm::MachineBasicBlock &MBB, llvm::MachineInstr &MI,
+            llvm::SmallVectorImpl<llvm::MachineInstr *> &ToRemove) {
+          replaceWithAVX(MBB, MI, ToRemove);
+        };
+
+    applyOptimizations(MF, shouldTransform, transformInstr);
+  }
+
+  void combineLogicOperations(llvm::MachineFunction &MF) {
+    OptimizationPredicate shouldTransform = [&](llvm::MachineInstr &MI) {
+      return isLogicOpcode(MI.getOpcode());
+    };
+
+    OptimizationTransform transformInstr =
+        [&](llvm::MachineBasicBlock &MBB, llvm::MachineInstr &MI,
+            llvm::SmallVectorImpl<llvm::MachineInstr *> &InstrsToRemove) {
+          llvm::Register IntermediateReg = MI.getOperand(1).getReg();
+          auto *FirstInstr = MRI->getUniqueVRegDef(IntermediateReg);
+          if (!FirstInstr || !MRI->hasOneUse(IntermediateReg))
+            return;
+
+          unsigned FirstOpcode = FirstInstr->getOpcode();
+          if (!isLogicOpcode(FirstOpcode))
+            return;
+
+          unsigned AVXFirstOp = getAVXOpcode(FirstOpcode);
+          unsigned AVXSecondOp = getAVXOpcode(MI.getOpcode());
+          if (!AVXFirstOp || !AVXSecondOp)
+            return;
+
+          replaceWithAVX(MBB, *FirstInstr, InstrsToRemove);
+          replaceWithAVX(MBB, MI, InstrsToRemove);
+        };
+
+    applyOptimizations(MF, shouldTransform, transformInstr);
+  }
+
+public:
+  static char ID;
+  X86LogicOptPass() : llvm::MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(llvm::MachineFunction &MF) override {
+    Changed = false;
+    const auto *ST = &MF.getSubtarget<llvm::X86Subtarget>();
+    TII = ST->getInstrInfo();
+    MRI = &MF.getRegInfo();
+
+    optimizeLogicOperations(MF);
+    combineLogicOperations(MF);
+
+    return Changed;
+  }
+};
+
+char X86LogicOptPass::ID = 0;
+} // namespace
+
+static llvm::RegisterPass<X86LogicOptPass>
+    X("x86-logic-opt", "X86 Logical Operations Optimization Pass", false,
+      false);

--- a/llvm/compiler-course/backend/frolova_e_fma/CMakeLists.txt
+++ b/llvm/compiler-course/backend/frolova_e_fma/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "DecomposeFMAPass")
+set(Student "Frolova_Elizaveta")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/frolova_e_fma/frolova_e_pass.cpp
+++ b/llvm/compiler-course/backend/frolova_e_fma/frolova_e_pass.cpp
@@ -1,0 +1,94 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/TargetRegisterInfo.h"
+
+using namespace llvm;
+
+namespace {
+
+using OperandOrder = std::array<unsigned, 3>;
+
+class DecomposeFMAPass : public MachineFunctionPass {
+public:
+  static char ID;
+  DecomposeFMAPass() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    bool Changed = false;
+
+    for (auto &MBB : MF) {
+      for (auto MI = MBB.begin(); MI != MBB.end();) {
+        MachineInstr &Instr = *MI++;
+        if (isFMAOpcode(Instr.getOpcode())) {
+          Changed |= decomposeFMA(Instr, MBB);
+        }
+      }
+    }
+
+    return Changed;
+  }
+
+private:
+  const DenseMap<unsigned, OperandOrder> FMAOperandOrder = {
+      {X86::VFMADD213SSr, {2, 1, 3}}, {X86::VFMADD213SDr, {2, 1, 3}},
+      {X86::VFMADD213PSr, {2, 1, 3}}, {X86::VFMADD213PDr, {2, 1, 3}},
+      {X86::VFMADD231SSr, {2, 3, 1}}, {X86::VFMADD231SDr, {2, 3, 1}},
+      {X86::VFMADD231PSr, {2, 3, 1}}, {X86::VFMADD231PDr, {2, 3, 1}},
+      {X86::VFMADD132SSr, {1, 3, 2}}, {X86::VFMADD132SDr, {1, 3, 2}},
+      {X86::VFMADD132PSr, {1, 3, 2}}, {X86::VFMADD132PDr, {1, 3, 2}},
+  };
+
+  bool isFMAOpcode(unsigned Opcode) const {
+    return FMAOperandOrder.contains(Opcode);
+  }
+
+  std::pair<unsigned, unsigned> getMulAddOpcodes(unsigned Opcode) const {
+    if (Opcode == X86::VFMADD213SSr || Opcode == X86::VFMADD231SSr ||
+        Opcode == X86::VFMADD132SSr)
+      return {X86::VMULSSrr, X86::VADDSSrr};
+    if (Opcode == X86::VFMADD213SDr || Opcode == X86::VFMADD231SDr ||
+        Opcode == X86::VFMADD132SDr)
+      return {X86::VMULSDrr, X86::VADDSDrr};
+    if (Opcode == X86::VFMADD213PSr || Opcode == X86::VFMADD231PSr ||
+        Opcode == X86::VFMADD132PSr)
+      return {X86::VMULPSrr, X86::VADDPSrr};
+    return {X86::VMULPDrr, X86::VADDPDrr};
+  }
+
+  bool decomposeFMA(MachineInstr &MI, MachineBasicBlock &MBB) {
+    const X86InstrInfo *TII =
+        MBB.getParent()->getSubtarget<X86Subtarget>().getInstrInfo();
+    MachineRegisterInfo &MRI = MBB.getParent()->getRegInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    unsigned Opcode = MI.getOpcode();
+
+    auto It = FMAOperandOrder.find(Opcode);
+    assert(It != FMAOperandOrder.end() && "Unexpected FMA opcode!");
+    OperandOrder Order = It->second;
+
+    Register Dest = MI.getOperand(0).getReg();
+    Register A = MI.getOperand(Order[0]).getReg();
+    Register B = MI.getOperand(Order[1]).getReg();
+    Register C = MI.getOperand(Order[2]).getReg();
+
+    auto [MulOpcode, AddOpcode] = getMulAddOpcodes(Opcode);
+    Register Temp = MRI.createVirtualRegister(MRI.getRegClass(A));
+
+    BuildMI(MBB, MI, DL, TII->get(MulOpcode), Temp).addReg(A).addReg(B);
+    BuildMI(MBB, MI, DL, TII->get(AddOpcode), Dest).addReg(C).addReg(Temp);
+
+    MI.eraseFromParent();
+    return true;
+  }
+};
+
+char DecomposeFMAPass::ID = 0;
+
+static RegisterPass<DecomposeFMAPass>
+    X("fma-x86", "Decompose FMA into MUL + ADD", false, false);
+
+} // namespace

--- a/llvm/compiler-course/backend/khovansky_d_lab3/CMakeLists.txt
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "FMAFlatten")
+set(Student "Khovansky_Dmitry")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
@@ -123,5 +123,3 @@ char FMAFlatten::ID = 0;
 static llvm::RegisterPass<FMAFlatten>
     X("FMA-flatten-x86", "Decomposes FMA instructions into MUL and ADD", false,
       false);
-
-

--- a/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
@@ -53,8 +53,8 @@ public:
   }
 
 private:
-  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add, 
-                   unsigned &A_idx, unsigned &B_idx, unsigned &C_idx) {
+  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add, unsigned &A_idx,
+                   unsigned &B_idx, unsigned &C_idx) {
     switch (Op) {
     // Packed single-precision
     case X86::VFMADD132PSr:

--- a/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
@@ -27,15 +27,16 @@ public:
     for (auto &Block : MF) {
       for (auto Inst = Block.begin(), End = Block.end(); Inst != End;) {
         MachineInstr &MI = *Inst++;
-        unsigned MulOp, AddOp, MulOp1, MulOp2;
+        unsigned MulOp, AddOp;
+        unsigned A_idx, B_idx, C_idx;
 
-        if (!identifyFMA(MI.getOpcode(), MulOp, AddOp, MulOp1, MulOp2))
+        if (!identifyFMA(MI.getOpcode(), MulOp, AddOp, A_idx, B_idx, C_idx))
           continue;
 
         Register Dst = MI.getOperand(0).getReg();
-        Register A = MI.getOperand(1).getReg();
-        Register B = MI.getOperand(2).getReg();
-        Register C = MI.getOperand(3).getReg();
+        Register A = MI.getOperand(A_idx).getReg();
+        Register B = MI.getOperand(B_idx).getReg();
+        Register C = MI.getOperand(C_idx).getReg();
         DebugLoc Loc = MI.getDebugLoc();
 
         const TargetRegisterClass *RegClass = MRI.getRegClass(A);
@@ -52,63 +53,99 @@ public:
   }
 
 private:
-  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add, unsigned &MulOp1,
-                   unsigned &MulOp2) {
+  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add, 
+                   unsigned &A_idx, unsigned &B_idx, unsigned &C_idx) {
     switch (Op) {
     // Packed single-precision
     case X86::VFMADD132PSr:
       Mul = X86::MULPSrr;
       Add = X86::ADDPSrr;
+      A_idx = 1;
+      B_idx = 3;
+      C_idx = 2;
       return true;
     case X86::VFMADD213PSr:
       Mul = X86::MULPSrr;
       Add = X86::ADDPSrr;
+      A_idx = 2;
+      B_idx = 1;
+      C_idx = 3;
       return true;
     case X86::VFMADD231PSr:
       Mul = X86::MULPSrr;
       Add = X86::ADDPSrr;
+      A_idx = 2;
+      B_idx = 3;
+      C_idx = 1;
       return true;
 
     // Packed double-precision
     case X86::VFMADD132PDr:
       Mul = X86::MULPDrr;
       Add = X86::ADDPDrr;
+      A_idx = 1;
+      B_idx = 3;
+      C_idx = 2;
       return true;
     case X86::VFMADD213PDr:
       Mul = X86::MULPDrr;
       Add = X86::ADDPDrr;
+      A_idx = 2;
+      B_idx = 1;
+      C_idx = 3;
       return true;
     case X86::VFMADD231PDr:
       Mul = X86::MULPDrr;
       Add = X86::ADDPDrr;
+      A_idx = 2;
+      B_idx = 3;
+      C_idx = 1;
       return true;
 
     // Scalar single-precision
     case X86::VFMADD132SSr:
       Mul = X86::MULSSrr;
       Add = X86::ADDSSrr;
+      A_idx = 1;
+      B_idx = 3;
+      C_idx = 2;
       return true;
     case X86::VFMADD213SSr:
       Mul = X86::MULSSrr;
       Add = X86::ADDSSrr;
+      A_idx = 2;
+      B_idx = 1;
+      C_idx = 3;
       return true;
     case X86::VFMADD231SSr:
       Mul = X86::MULSSrr;
       Add = X86::ADDSSrr;
+      A_idx = 2;
+      B_idx = 3;
+      C_idx = 1;
       return true;
 
     // Scalar double-precision
     case X86::VFMADD132SDr:
       Mul = X86::MULSDrr;
       Add = X86::ADDSDrr;
+      A_idx = 1;
+      B_idx = 3;
+      C_idx = 2;
       return true;
     case X86::VFMADD213SDr:
       Mul = X86::MULSDrr;
       Add = X86::ADDSDrr;
+      A_idx = 2;
+      B_idx = 1;
+      C_idx = 3;
       return true;
     case X86::VFMADD231SDr:
       Mul = X86::MULSDrr;
       Add = X86::ADDSDrr;
+      A_idx = 2;
+      B_idx = 3;
+      C_idx = 1;
       return true;
 
     default:

--- a/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
@@ -33,8 +33,8 @@ public:
           continue;
 
         Register Dst = MI.getOperand(0).getReg();
-        Register A = MI.getOperand(MulOp1).getReg();
-        Register B = MI.getOperand(MulOp2).getReg();
+        Register A = MI.getOperand(1).getReg();
+        Register B = MI.getOperand(2).getReg();
         Register C = MI.getOperand(3).getReg();
         DebugLoc Loc = MI.getDebugLoc();
 
@@ -52,52 +52,64 @@ public:
   }
 
 private:
-  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add,
-                   unsigned &MulOp1, unsigned &MulOp2) {
+  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add, unsigned &MulOp1,
+                   unsigned &MulOp2) {
     switch (Op) {
     // Packed single-precision
     case X86::VFMADD132PSr:
-      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPSrr;
+      Add = X86::ADDPSrr;
+      return true;
     case X86::VFMADD213PSr:
-      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPSrr;
+      Add = X86::ADDPSrr;
+      return true;
     case X86::VFMADD231PSr:
-      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPSrr;
+      Add = X86::ADDPSrr;
+      return true;
 
     // Packed double-precision
     case X86::VFMADD132PDr:
-      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPDrr;
+      Add = X86::ADDPDrr;
+      return true;
     case X86::VFMADD213PDr:
-      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPDrr;
+      Add = X86::ADDPDrr;
+      return true;
     case X86::VFMADD231PDr:
-      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULPDrr;
+      Add = X86::ADDPDrr;
+      return true;
 
     // Scalar single-precision
     case X86::VFMADD132SSr:
-      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSSrr;
+      Add = X86::ADDSSrr;
+      return true;
     case X86::VFMADD213SSr:
-      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSSrr;
+      Add = X86::ADDSSrr;
+      return true;
     case X86::VFMADD231SSr:
-      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSSrr;
+      Add = X86::ADDSSrr;
+      return true;
 
     // Scalar double-precision
     case X86::VFMADD132SDr:
-      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSDrr;
+      Add = X86::ADDSDrr;
+      return true;
     case X86::VFMADD213SDr:
-      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSDrr;
+      Add = X86::ADDSDrr;
+      return true;
     case X86::VFMADD231SDr:
-      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
-      MulOp1 = 1; MulOp2 = 2; return true;
+      Mul = X86::MULSDrr;
+      Add = X86::ADDSDrr;
+      return true;
 
     default:
       return false;
@@ -109,5 +121,7 @@ char FMAFlatten::ID = 0;
 } // namespace
 
 static llvm::RegisterPass<FMAFlatten>
-    X("FMA-flatten-x86", "Decomposes FMA instructions into MUL and ADD", false, false);
+    X("FMA-flatten-x86", "Decomposes FMA instructions into MUL and ADD", false,
+      false);
+
 

--- a/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
+++ b/llvm/compiler-course/backend/khovansky_d_lab3/khovansky_d_lab3.cpp
@@ -1,0 +1,113 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/Support/Debug.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "fma-decompose"
+
+namespace {
+class FMAFlatten : public MachineFunctionPass {
+public:
+  static char ID;
+  FMAFlatten() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    auto &ST = MF.getSubtarget<X86Subtarget>();
+    auto *TII = ST.getInstrInfo();
+    auto &MRI = MF.getRegInfo();
+    bool Changed = false;
+
+    for (auto &Block : MF) {
+      for (auto Inst = Block.begin(), End = Block.end(); Inst != End;) {
+        MachineInstr &MI = *Inst++;
+        unsigned MulOp, AddOp, MulOp1, MulOp2;
+
+        if (!identifyFMA(MI.getOpcode(), MulOp, AddOp, MulOp1, MulOp2))
+          continue;
+
+        Register Dst = MI.getOperand(0).getReg();
+        Register A = MI.getOperand(MulOp1).getReg();
+        Register B = MI.getOperand(MulOp2).getReg();
+        Register C = MI.getOperand(3).getReg();
+        DebugLoc Loc = MI.getDebugLoc();
+
+        const TargetRegisterClass *RegClass = MRI.getRegClass(A);
+        Register Temp = MRI.createVirtualRegister(RegClass);
+
+        BuildMI(Block, MI, Loc, TII->get(MulOp), Temp).addReg(A).addReg(B);
+        BuildMI(Block, MI, Loc, TII->get(AddOp), Dst).addReg(C).addReg(Temp);
+        MI.eraseFromParent();
+        Changed = true;
+      }
+    }
+
+    return Changed;
+  }
+
+private:
+  bool identifyFMA(unsigned Op, unsigned &Mul, unsigned &Add,
+                   unsigned &MulOp1, unsigned &MulOp2) {
+    switch (Op) {
+    // Packed single-precision
+    case X86::VFMADD132PSr:
+      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD213PSr:
+      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD231PSr:
+      Mul = X86::MULPSrr; Add = X86::ADDPSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+
+    // Packed double-precision
+    case X86::VFMADD132PDr:
+      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD213PDr:
+      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD231PDr:
+      Mul = X86::MULPDrr; Add = X86::ADDPDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+
+    // Scalar single-precision
+    case X86::VFMADD132SSr:
+      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD213SSr:
+      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD231SSr:
+      Mul = X86::MULSSrr; Add = X86::ADDSSrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+
+    // Scalar double-precision
+    case X86::VFMADD132SDr:
+      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD213SDr:
+      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+    case X86::VFMADD231SDr:
+      Mul = X86::MULSDrr; Add = X86::ADDSDrr;
+      MulOp1 = 1; MulOp2 = 2; return true;
+
+    default:
+      return false;
+    }
+  }
+};
+
+char FMAFlatten::ID = 0;
+} // namespace
+
+static llvm::RegisterPass<FMAFlatten>
+    X("FMA-flatten-x86", "Decomposes FMA instructions into MUL and ADD", false, false);
+

--- a/llvm/compiler-course/backend/kozlova_lab3_var4/CMakeLists.txt
+++ b/llvm/compiler-course/backend/kozlova_lab3_var4/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "ExamplePass")
+set(Student "Kozlova_Ekaterina")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/kozlova_lab3_var4/ExamplePass.cpp
+++ b/llvm/compiler-course/backend/kozlova_lab3_var4/ExamplePass.cpp
@@ -1,0 +1,96 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
+
+#define DEBUG_TYPE "mul_sub"
+
+using namespace llvm;
+
+namespace {
+class MulSubPass : public MachineFunctionPass {
+public:
+  static char ID;
+  MulSubPass() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    const X86Subtarget &ST = MF.getSubtarget<X86Subtarget>();
+    const X86InstrInfo *TII = ST.getInstrInfo();
+    MachineRegisterInfo &MRI = MF.getRegInfo();
+    bool Changed = false;
+
+    for (MachineBasicBlock &MBB : MF) {
+      for (MachineBasicBlock::iterator MI = MBB.begin(), ME = MBB.end();
+           MI != ME;) {
+        MachineInstr &Sub = *MI++;
+
+        if (!isFloatingPointSubtraction(Sub))
+          continue;
+
+        MachineInstr *Mul = findMultiplyInstruction(MRI, Sub);
+        if (!Mul)
+          continue;
+
+        fuseMultiplySubtract(MBB, MI, Sub, Mul, TII);
+        Changed = true;
+      }
+    }
+
+    return Changed;
+  }
+
+private:
+  bool isFloatingPointSubtraction(const MachineInstr &MI) const {
+    unsigned Opcode = MI.getOpcode();
+    return Opcode == X86::VSUBSSrr || Opcode == X86::VSUBSDrr;
+  }
+
+  MachineInstr *findMultiplyInstruction(MachineRegisterInfo &MRI,
+                                        const MachineInstr &Sub) const {
+    Register SubOp2 = Sub.getOperand(2).getReg();
+    MachineInstr *Mul = MRI.getUniqueVRegDef(SubOp2);
+    if (!Mul)
+      return nullptr;
+
+    unsigned MulOpcode = Mul->getOpcode();
+    return (MulOpcode == X86::VMULSSrr || MulOpcode == X86::VMULSDrr) ? Mul
+                                                                      : nullptr;
+  }
+
+  void fuseMultiplySubtract(MachineBasicBlock &MBB,
+                            MachineBasicBlock::iterator &MI, MachineInstr &Sub,
+                            MachineInstr *Mul, const X86InstrInfo *TII) {
+    Register SubDst = Sub.getOperand(0).getReg();
+    Register SubOp1 = Sub.getOperand(1).getReg();
+    Register MulOp1 = Mul->getOperand(1).getReg();
+    Register MulOp2 = Mul->getOperand(2).getReg();
+    DebugLoc DL = Sub.getDebugLoc();
+
+    unsigned NewOpcode = (Sub.getOpcode() == X86::VSUBSSrr)
+                             ? X86::VFNMADD213SSr
+                             : X86::VFNMADD213SDr;
+
+    BuildMI(MBB, &Sub, DL, TII->get(NewOpcode), SubDst)
+        .addReg(SubOp1)
+        .addReg(MulOp1)
+        .addReg(MulOp2)
+        .addReg(X86::MXCSR, RegState::Implicit);
+
+    Sub.eraseFromParent();
+    Mul->eraseFromParent();
+
+    MI = std::next(MBB.begin(), 1);
+  }
+};
+char MulSubPass::ID = 0;
+} // namespace
+
+static RegisterPass<MulSubPass>
+    X("mul_sub", "Fuse MUL + SUB into VFMSUB213 instructions", false, false);

--- a/llvm/compiler-course/backend/lavrentyevBackendPass/CMakeLists.txt
+++ b/llvm/compiler-course/backend/lavrentyevBackendPass/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "FMSUBComposePass")
+set(Student "Lavrentyev_Alexey")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/lavrentyevBackendPass/FMSUBComposePass.cpp
+++ b/llvm/compiler-course/backend/lavrentyevBackendPass/FMSUBComposePass.cpp
@@ -1,0 +1,114 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/Passes/PassBuilder.h"
+
+#define DEBUG_TYPE "fmsub-compose"
+
+using namespace llvm;
+
+namespace {
+class FMSUBComposePass : public MachineFunctionPass {
+public:
+  static char ID;
+  FMSUBComposePass() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    const X86Subtarget &ST = MF.getSubtarget<X86Subtarget>();
+    if (!ST.hasFMA())
+      return false;
+
+    const X86InstrInfo *TII = ST.getInstrInfo();
+    bool Changed = false;
+
+    for (auto &MBB : MF) {
+      SmallVector<MachineInstr *, 8> ToErase;
+
+      for (auto MIit = MBB.instr_begin(), ME = MBB.instr_end(); MIit != ME;
+           ++MIit) {
+        MachineInstr &MulMI = *MIit;
+        unsigned MulOpc = MulMI.getOpcode();
+        unsigned SubOpc = 0, FMAOpc = 0;
+
+        switch (MulOpc) {
+        case X86::MULPSrm:
+          SubOpc = X86::SUBPSrr;
+          FMAOpc = X86::VFMSUB213PSm;
+          break;
+        case X86::MULPDrm:
+          SubOpc = X86::SUBPDrr;
+          FMAOpc = X86::VFMSUB213PDm;
+          break;
+        case X86::MULSSrm:
+          SubOpc = X86::SUBSSrr;
+          FMAOpc = X86::VFMSUB213SSm;
+          break;
+        case X86::MULSDrm:
+          SubOpc = X86::SUBSDrr;
+          FMAOpc = X86::VFMSUB213SDm;
+          break;
+        default:
+          continue;
+        }
+
+        MachineInstr *SubMI = nullptr;
+        Register TmpReg = MulMI.getOperand(0).getReg();
+        auto ScanIt = std::next(MIit);
+        for (; ScanIt != ME; ++ScanIt) {
+          for (auto &Op : ScanIt->operands()) {
+            if (Op.isReg() && Op.isDef() && Op.getReg() == TmpReg) {
+              ScanIt = ME;
+              break;
+            }
+          }
+          if (ScanIt == ME)
+            break;
+          if (ScanIt->getOpcode() == SubOpc &&
+              ScanIt->getOperand(2).getReg() == TmpReg) {
+            SubMI = &*ScanIt;
+            break;
+          }
+        }
+        if (!SubMI)
+          continue;
+
+        Register Dst = SubMI->getOperand(0).getReg();
+        Register C = SubMI->getOperand(1).getReg();
+        DebugLoc DL = MulMI.getDebugLoc();
+
+        auto MIB = BuildMI(MBB, MulMI, DL, TII->get(FMAOpc), Dst);
+
+        Register A = MulMI.getOperand(2).getReg();
+        MIB.addReg(A);
+        for (auto *MO : MulMI.memoperands()) {
+          auto *MMO_nc = const_cast<MachineMemOperand *>(MO);
+          MIB.addMemOperand(MMO_nc);
+        }
+        MIB.addReg(C);
+
+        ToErase.push_back(&MulMI);
+        ToErase.push_back(SubMI);
+        Changed = true;
+      }
+
+      for (auto *MI : ToErase)
+        MI->eraseFromParent();
+    }
+
+    return Changed;
+  }
+};
+
+char FMSUBComposePass::ID = 0;
+
+static RegisterPass<FMSUBComposePass>
+    X("fmsub-compose-x86",
+      "Compose MULrm+SUBrr into a single fused multiply‑subtract (mem‑reg)",
+      false, false);
+
+} // namespace

--- a/llvm/compiler-course/backend/shurigin_s_4var/CMakeLists.txt
+++ b/llvm/compiler-course/backend/shurigin_s_4var/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "SUBPass")
+set(Student "Shurigin_S")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/shurigin_s_4var/Shurigin_s_4var.cpp
+++ b/llvm/compiler-course/backend/shurigin_s_4var/Shurigin_s_4var.cpp
@@ -1,0 +1,199 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "shurigin-fmsub-combine"
+
+using namespace llvm;
+
+namespace {
+
+class SUBPass : public MachineFunctionPass {
+public:
+  static char ID;
+  SUBPass() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+
+  StringRef getPassName() const override {
+    return "Simple Fused Multiply-Subtract Combine (Shurigin)";
+  }
+
+private:
+  bool isSupportedMul(unsigned Opcode) const {
+    switch (Opcode) {
+    case X86::VMULSSrr:
+    case X86::VMULSDrr:
+    case X86::VMULPSrr:
+    case X86::VMULPDrr:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  bool isSupportedSub(unsigned Opcode) const {
+    switch (Opcode) {
+    case X86::VSUBSSrr:
+    case X86::VSUBSDrr:
+    case X86::VSUBPSrr:
+    case X86::VSUBPDrr:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  unsigned getFMAOpcode(unsigned SubOpcode) const {
+    switch (SubOpcode) {
+    case X86::VSUBSSrr:
+      return X86::VFNMADD213SSr;
+    case X86::VSUBSDrr:
+      return X86::VFNMADD213SDr;
+    case X86::VSUBPSrr:
+      return X86::VFNMADD213PSr;
+    case X86::VSUBPDrr:
+      return X86::VFNMADD213PDr;
+    default:
+      return 0;
+    }
+  }
+};
+
+char SUBPass::ID = 0;
+
+bool SUBPass::runOnMachineFunction(MachineFunction &MF) {
+
+  const X86Subtarget &Subtarget = MF.getSubtarget<X86Subtarget>();
+  const X86InstrInfo *TII = Subtarget.getInstrInfo();
+  LLVM_DEBUG(dbgs() << "\nRunning SUBPass on function: " << MF.getName()
+                    << '\n');
+
+  if (!Subtarget.hasFMA()) {
+    LLVM_DEBUG(dbgs() << "  Target does not support FMA. Skipping pass.\n");
+    return false;
+  }
+
+  bool Changed = false;
+  SmallVector<MachineInstr *, 4> InstrsToDelete;
+
+  for (MachineBasicBlock &MBB : MF) {
+    LLVM_DEBUG(dbgs() << " Processing MBB: " << MBB.getName() << '\n');
+    InstrsToDelete.clear();
+
+    for (auto MBBI = MBB.begin(), MBBE = MBB.end(); MBBI != MBBE; ++MBBI) {
+      MachineInstr &SubMI = *MBBI;
+
+      LLVM_DEBUG(dbgs() << "  Checking instruction: "; SubMI.dump(););
+
+      if (!isSupportedSub(SubMI.getOpcode())) {
+        LLVM_DEBUG(dbgs() << "    Not a supported AVX SUB opcode.\n");
+        continue;
+      }
+
+      if (MBBI == MBB.begin()) {
+        LLVM_DEBUG(
+            dbgs() << "    SUB is the first instruction in the block.\n");
+        continue;
+      }
+      MachineInstr *MulMIPtr = &*std::prev(MBBI);
+      if (!MulMIPtr)
+        continue;
+      MachineInstr &MulMI = *MulMIPtr;
+
+      LLVM_DEBUG(dbgs() << "    Preceding instruction: "; MulMI.dump(););
+
+      if (!isSupportedMul(MulMI.getOpcode())) {
+        LLVM_DEBUG(dbgs() << "    Preceding instruction is not a supported AVX "
+                             "MUL opcode.\n");
+        continue;
+      }
+
+      if (MulMI.getNumExplicitOperands() < 3 || !MulMI.getOperand(0).isReg() ||
+          !MulMI.getOperand(1).isReg() || !MulMI.getOperand(2).isReg()) {
+        LLVM_DEBUG(
+            dbgs()
+            << "    MUL operands mismatch expected 3-register pattern.\n");
+        continue;
+      }
+      if (SubMI.getNumExplicitOperands() < 3 || !SubMI.getOperand(0).isReg() ||
+          !SubMI.getOperand(1).isReg() || !SubMI.getOperand(2).isReg()) {
+        LLVM_DEBUG(
+            dbgs()
+            << "    SUB operands mismatch expected 3-register pattern.\n");
+        continue;
+      }
+
+      Register MulDstReg = MulMI.getOperand(0).getReg();
+      Register AReg = MulMI.getOperand(1).getReg();
+      Register BReg = MulMI.getOperand(2).getReg();
+
+      Register DstReg = SubMI.getOperand(0).getReg();
+      Register CReg = SubMI.getOperand(1).getReg();
+      Register TmpReg = SubMI.getOperand(2).getReg();
+
+      if (MulDstReg != TmpReg) {
+        LLVM_DEBUG(dbgs() << "    SUB's second operand register doesn't match "
+                             "MUL's destination register.\n");
+        continue;
+      }
+
+      if (!SubMI.getOperand(2).isKill()) {
+        LLVM_DEBUG(dbgs() << "    Safety check failed: TmpReg is not killed by "
+                             "SUB. Skipping optimization.\n");
+        continue;
+      }
+
+      unsigned FMAOpcode = getFMAOpcode(SubMI.getOpcode());
+      if (FMAOpcode == 0) {
+        LLVM_DEBUG(dbgs() << "    Could not find matching FMA opcode for SUB: "
+                          << TII->getName(SubMI.getOpcode()) << "\n");
+        continue;
+      }
+
+      LLVM_DEBUG(dbgs() << "  Pattern Found! Replacing with FMA.\n");
+      LLVM_DEBUG(dbgs() << "    Using FMA Opcode: " << TII->getName(FMAOpcode)
+                        << "\n");
+
+      MachineInstr *NewMI =
+          BuildMI(MBB, SubMI, SubMI.getDebugLoc(), TII->get(FMAOpcode), DstReg)
+              .addReg(AReg, getRegState(MulMI.getOperand(1)))
+              .addReg(BReg, getRegState(MulMI.getOperand(2)))
+              .addReg(CReg, getRegState(SubMI.getOperand(1)))
+              .getInstr();
+      (void)NewMI;
+
+      LLVM_DEBUG(dbgs() << "  New instruction created: "; NewMI->dump(););
+
+      InstrsToDelete.push_back(&MulMI);
+      InstrsToDelete.push_back(&SubMI);
+
+      Changed = true;
+      LLVM_DEBUG(dbgs() << "  Marked instructions for deletion.\n");
+    }
+
+    if (!InstrsToDelete.empty()) {
+      LLVM_DEBUG(dbgs() << " Deleting marked instructions for MBB "
+                        << MBB.getName() << "\n");
+      for (MachineInstr *MI : reverse(InstrsToDelete)) {
+        LLVM_DEBUG(dbgs() << "  Deleting: "; MI->dump(););
+        MI->eraseFromParent();
+      }
+    }
+  }
+
+  LLVM_DEBUG(dbgs() << "SUBPass finished. Changes made: " << Changed << "\n");
+  return Changed;
+}
+
+} // namespace
+
+static RegisterPass<SUBPass>
+    X(DEBUG_TYPE, "Simple Fused Multiply-Subtract Combine (Shurigin)", false,
+      false);

--- a/llvm/compiler-course/backend/solovev_a/CMakeLists.txt
+++ b/llvm/compiler-course/backend/solovev_a/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(Title "Lab_3_backend")
+set(Student "Solovev_a")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_BACKEND")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY
+)
+
+target_include_directories(${TARGET_NAME} PUBLIC ${PATH_TO_X86})
+set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
+++ b/llvm/compiler-course/backend/solovev_a/solovev_a.cpp
@@ -1,0 +1,76 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
+
+#define DEBUG_TYPE "mul_sub_solovev"
+
+using namespace llvm;
+
+namespace {
+
+class FMSUBComposePass : public MachineFunctionPass {
+public:
+  static char ID;
+  FMSUBComposePass() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    const X86Subtarget &ST = MF.getSubtarget<X86Subtarget>();
+    if (!ST.hasFMA())
+      return false;
+    const X86InstrInfo *TII = ST.getInstrInfo();
+    auto &MRI = MF.getRegInfo();
+    bool Changed = false;
+    for (auto &MBB : MF) {
+      for (auto MI = MBB.instr_begin(), ME = MBB.instr_end(); MI != ME;) {
+        MachineInstr &Sub = *MI++;
+        if (Sub.isMetaInstruction())
+          continue;
+        unsigned SubOpcode = Sub.getOpcode();
+        if (SubOpcode != X86::VSUBSSrr && SubOpcode != X86::VSUBSDrr)
+          continue;
+        Register SubDst = Sub.getOperand(0).getReg();
+        Register SubOp1 = Sub.getOperand(1).getReg();
+        Register SubOp2 = Sub.getOperand(2).getReg();
+        if (!MRI.hasOneUse(SubOp2))
+          continue;
+        MachineInstr *Mul = MRI.getUniqueVRegDef(SubOp2);
+        if (!Mul)
+          continue;
+        unsigned MulOpcode = Mul->getOpcode();
+        if (MulOpcode != X86::VMULSSrr && MulOpcode != X86::VMULSDrr)
+          continue;
+        Register MulOp1 = Mul->getOperand(1).getReg();
+        Register MulOp2 = Mul->getOperand(2).getReg();
+        DebugLoc DL = Sub.getDebugLoc();
+        MachineBasicBlock &MBBRef = *Sub.getParent();
+        unsigned NewOpcode = (SubOpcode == X86::VSUBSSrr) ? X86::VFNMADD213SSr
+                                                          : X86::VFNMADD213SDr;
+        BuildMI(MBBRef, &Sub, DL, TII->get(NewOpcode), SubDst)
+            .addReg(SubOp1)
+            .addReg(MulOp1)
+            .addReg(MulOp2)
+            .addImm(0)
+            .addReg(X86::MXCSR, RegState::Implicit);
+        Sub.eraseFromParent();
+        Mul->eraseFromParent();
+        Changed = true;
+      }
+    }
+    return Changed;
+  }
+};
+char FMSUBComposePass::ID = 0;
+
+} // namespace
+
+static RegisterPass<FMSUBComposePass>
+    X("mul_sub_solovev", "Fuse MUL + SUB into VFNMADD213 instructions", false,
+      false);

--- a/llvm/test/compiler-course/AddToCallPass-Mamaeva-Lab3/test-add.mir
+++ b/llvm/test/compiler-course/AddToCallPass-Mamaeva-Lab3/test-add.mir
@@ -1,0 +1,50 @@
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu \
+# RUN:     --load=%llvmshlibdir/FMADecomposePass_Mamaeva_Olga_FIIT3_BACKEND%shlibext \
+# RUN:     -run-pass=fma-decompose %s -o - | FileCheck %s
+
+--- |
+  ; ModuleID = 'test-fma.c'
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-unknown-linux-gnu"
+
+  ; Объявления функций для тестирования всех вариантов
+  declare <4 x float> @llvm.fma.v4f32(<4 x float>, <4 x float>, <4 x float>)
+  declare <2 x double> @llvm.fma.v2f64(<2 x double>, <2 x double>, <2 x double>)
+  declare float @llvm.fma.f32(float, float, float)
+  declare double @llvm.fma.f64(double, double, double)
+
+  define void @test_all_types(<4 x float> %a, <2 x double> %b, float %c, double %d) {
+    ret void
+  }
+...
+---
+name:            test_all_types
+body:             |
+  bb.0 (%ir-block.0):
+    liveins: $xmm0, $xmm1, $xmm2, $xmm3
+
+    ; 1. Проверка VFMADD*PSr (упакованные float)
+    ; CHECK:      [[TMP1:%.*]]:vr128 = MULPSrr %0, %0, implicit $mxcsr
+    ; CHECK-NEXT: %0:vr128 = ADDPSrr %0, [[TMP1]], implicit $mxcsr
+    %0:vr128 = COPY $xmm0
+    %0:vr128 = VFMADD132PSr %0, %0, %0, implicit $mxcsr
+
+    ; 2. Проверка VFMADD*PDr (упакованные double)
+    ; CHECK:      [[TMP2:%.*]]:vr128 = MULPDrr %1, %1, implicit $mxcsr
+    ; CHECK-NEXT: %1:vr128 = ADDPDrr %1, [[TMP2]], implicit $mxcsr
+    %1:vr128 = COPY $xmm1
+    %1:vr128 = VFMADD213PDr %1, %1, %1, implicit $mxcsr
+
+    ; 3. Проверка VFMADD*SSr (скалярные float)
+    ; CHECK:      [[TMP3:%.*]]:fr32 = MULSSrr %2, %2, implicit $mxcsr
+    ; CHECK-NEXT: %2:fr32 = ADDSSrr %2, [[TMP3]], implicit $mxcsr
+    %2:fr32 = COPY $xmm2
+    %2:fr32 = VFMADD231SSr %2, %2, %2, implicit $mxcsr
+
+    ; 4. Проверка VFMADD*SDr (скалярные double)
+    ; CHECK:      [[TMP4:%.*]]:fr64 = MULSDrr %3, %3, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr64 = ADDSDrr %3, [[TMP4]], implicit $mxcsr
+    %3:fr64 = COPY $xmm3
+    %3:fr64 = VFMADD132SDr %3, %3, %3, implicit $mxcsr
+
+    RET 0

--- a/llvm/test/compiler-course/Shurigin_lab3/test_backend.mir
+++ b/llvm/test/compiler-course/Shurigin_lab3/test_backend.mir
@@ -1,0 +1,388 @@
+#  RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+fma \
+#  RUN:     --load=%llvmshlibdir/SUBPass_Shurigin_S_FIIT1_BACKEND%shlibext \
+#  RUN:     -run-pass=shurigin-fmsub-combine %s -o - | FileCheck %s
+
+--- |
+  ; ModuleID = 'MulSubTests_ShuriginS_Reg.ll'
+  source_filename = "MulSubTests_ShuriginS_Reg.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+
+  module asm ".globl _ZSt21ios_base_library_initv"
+
+  %"class.std::basic_ostream" = type { ptr, %"class.std::basic_ios" }
+  %"class.std::basic_ios" = type { %"class.std::ios_base", ptr, i8, i8, ptr, ptr, ptr, ptr }
+  %"class.std::ios_base" = type { ptr, i64, i64, i32, i32, i32, ptr, %"struct.std::ios_base::_Words", [8 x %"struct.std::ios_base::_Words"], i32, ptr, %"class.std::locale" }
+  %"struct.std::ios_base::_Words" = type { ptr, i64 }
+  %"class.std::locale" = type { ptr }
+
+  @_ZSt4cout = external global %"class.std::basic_ostream", align 8
+
+  ; Function Attrs: nounwind uwtable mustprogress noinline
+  define dso_local noundef float @ss_test_shurigin(float noundef %a, float noundef %b, float noundef %c) #0 {
+  entry:
+    %tmp = fmul float %a, %b
+    %d = fsub float %c, %tmp
+    ret float %d
+  }
+
+  ; Function Attrs: nounwind uwtable mustprogress noinline
+  define dso_local noundef float @ss_rev_sub_test_shurigin(float noundef %a, float noundef %b, float noundef %c) #0 {
+  entry:
+    %tmp = fmul float %a, %b
+    %neg_tmp = fneg float %tmp
+    %d = fadd float %c, %neg_tmp ;c - tmp
+    ret float %d
+  }
+
+  ; Function Attrs: nounwind uwtable mustprogress noinline
+  define dso_local noundef float @ss_mul_rev_test_shurigin(float noundef %a, float noundef %b, float noundef %c) #0 {
+  entry:
+    %tmp = fmul float %b, %a
+    %d = fsub float %c, %tmp
+    ret float %d
+  }
+
+
+  ; Function Attrs: nounwind uwtable mustprogress noinline
+  define dso_local noundef double @sd_test_shurigin(double noundef %a, double noundef %b, double noundef %c) #0 {
+  entry:
+    %tmp = fmul double %a, %b
+    %d = fsub double %c, %tmp
+    ret double %d
+  }
+
+
+
+  attributes #0 = { mustprogress noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87,+fma" "tune-cpu"="generic" }
+
+  !llvm.module.flags = !{!0, !1, !2, !3, !4}
+  !llvm.ident = !{!5}
+
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 2}
+  !4 = !{i32 7, !"frame-pointer", i32 2}
+  !5 = !{!"Shurigin Custom Clang"}
+
+# CHECK-LABEL: name: ss_test_shurigin
+# CHECK: bb.0.entry:
+# CHECK-NOT: VMULSSrr
+# CHECK-NOT: VSUBSSrr
+# CHECK: %[[RES:.+]]:fr32 = VFNMADD213SSr{{.*}}
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+...
+---
+name:            ss_test_shurigin
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+  - { id: 4, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    %2:fr32 = COPY $xmm2  ; c
+    %1:fr32 = COPY $xmm1  ; b
+    %0:fr32 = COPY $xmm0  ; a
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr  ; tmp = a * b
+    %4:fr32 = nofpexcept VSUBSSrr %2, killed %3, implicit $mxcsr ; d = c - tmp
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+
+# CHECK-LABEL: name: ss_rev_sub_test_shurigin
+# CHECK: bb.0.entry:
+# CHECK-NOT: VMULSSrr
+# CHECK-NOT: VSUBSSrr
+# CHECK: %[[RES:.+]]:fr32 = VFNMADD213SSr{{.*}}
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+...
+---
+name:            ss_rev_sub_test_shurigin
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+  - { id: 4, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    %2:fr32 = COPY $xmm2  ; c
+    %1:fr32 = COPY $xmm1  ; b
+    %0:fr32 = COPY $xmm0  ; a
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr  ; tmp = a * b
+    %4:fr32 = nofpexcept VSUBSSrr %2, killed %3, implicit $mxcsr ; d = c - tmp
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+
+# CHECK-LABEL: name: ss_mul_rev_test_shurigin
+# CHECK: bb.0.entry:
+# CHECK-NOT: VMULSSrr
+# CHECK-NOT: VSUBSSrr
+# CHECK: %[[RES:.+]]:fr32 = VFNMADD213SSr{{.*}}
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+...
+---
+name:            ss_mul_rev_test_shurigin
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+  - { id: 4, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    %2:fr32 = COPY $xmm2  ; c
+    %1:fr32 = COPY $xmm1  ; b
+    %0:fr32 = COPY $xmm0  ; a
+    %3:fr32 = nofpexcept VMULSSrr %1, %0, implicit $mxcsr  ; tmp = b * a
+    %4:fr32 = nofpexcept VSUBSSrr %2, killed %3, implicit $mxcsr ; d = c - tmp
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+
+
+# CHECK-LABEL: name: sd_test_shurigin
+# CHECK: bb.0.entry:
+# CHECK-NOT: VMULSDrr
+# CHECK-NOT: VSUBSDrr
+# CHECK: %[[RES:.+]]:fr64 = VFNMADD213SDr{{.*}}
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+...
+---
+name:            sd_test_shurigin
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64, preferred-register: '' }
+  - { id: 1, class: fr64, preferred-register: '' }
+  - { id: 2, class: fr64, preferred-register: '' }
+  - { id: 3, class: fr64, preferred-register: '' }
+  - { id: 4, class: fr64, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    %2:fr64 = COPY $xmm2  ; c
+    %1:fr64 = COPY $xmm1  ; b
+    %0:fr64 = COPY $xmm0  ; a
+    %3:fr64 = nofpexcept VMULSDrr %0, %1, implicit $mxcsr  ; tmp = a * b
+    %4:fr64 = nofpexcept VSUBSDrr %2, killed %3, implicit $mxcsr ; d = c - tmp
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0

--- a/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
+++ b/llvm/test/compiler-course/chistov_a_combination_test/chistov_a_backend_test.mir
@@ -1,0 +1,401 @@
+# RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/CombinationPass_Chistov_Alexey_FIIT1_BACKEND%shlibext \
+# RUN: -run-pass=x86-logic-opt %s -o - | FileCheck %s
+
+# Source files
+# test.cpp
+
+#include <emmintrin.h>
+
+#__m128 test_basic_and_operation(__m128 a, __m128 b) {
+#    return _mm_and_ps(a, b);
+#}
+
+#__m128 test_basic_or_operation(__m128 a, __m128 b) {
+#    return _mm_or_ps(a, b);
+#}
+
+#__m128 test_basic_xor_operation(__m128 a, __m128 b) {
+#    return _mm_xor_ps(a, b);
+#}
+
+#__m128 test_and_with_self_is_copy(__m128 a) {
+#    return _mm_and_ps(a, a);
+#}
+
+#__m128 test_or_with_self(__m128 a) {
+#    return _mm_or_ps(a, a);
+#}
+
+#__m128 test_combined_logic_operations(__m128 a, __m128 b, __m128 c) {
+#    __m128 t1 = _mm_and_ps(a, b);
+#    __m128 t2 = _mm_or_ps(t1, c);
+#    __m128 t3 = _mm_xor_ps(t2, a);
+#    return t3;
+#} 
+
+--- |
+  ; ModuleID = 'llvm/test/compiler-course/chistov_a_combination_test/test.ll'
+  source_filename = "/home/alexe/code/compiler-course-2025/llvm/test/compiler-course/chistov_a_combination_test/test.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-unknown-linux-gnu"
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z24test_basic_and_operationDv4_fS_(<4 x float> noundef %a, <4 x float> noundef %b) local_unnamed_addr #0 {
+  entry:
+    %0 = bitcast <4 x float> %a to <4 x i32>
+    %1 = bitcast <4 x float> %b to <4 x i32>
+    %and.i = and <4 x i32> %1, %0
+    %2 = bitcast <4 x i32> %and.i to <4 x float>
+    ret <4 x float> %2
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z23test_basic_or_operationDv4_fS_(<4 x float> noundef %a, <4 x float> noundef %b) local_unnamed_addr #0 {
+  entry:
+    %0 = bitcast <4 x float> %a to <4 x i32>
+    %1 = bitcast <4 x float> %b to <4 x i32>
+    %or.i = or <4 x i32> %1, %0
+    %2 = bitcast <4 x i32> %or.i to <4 x float>
+    ret <4 x float> %2
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z24test_basic_xor_operationDv4_fS_(<4 x float> noundef %a, <4 x float> noundef %b) local_unnamed_addr #0 {
+  entry:
+    %0 = bitcast <4 x float> %a to <4 x i32>
+    %1 = bitcast <4 x float> %b to <4 x i32>
+    %xor.i = xor <4 x i32> %1, %0
+    %2 = bitcast <4 x i32> %xor.i to <4 x float>
+    ret <4 x float> %2
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z30test_combined_logic_operationsDv4_fS_S_(<4 x float> noundef %a, <4 x float> noundef %b, <4 x float> noundef %c) local_unnamed_addr #0 {
+  entry:
+    %0 = bitcast <4 x float> %a to <4 x i32>
+    %1 = bitcast <4 x float> %b to <4 x i32>
+    %and.i = and <4 x i32> %1, %0
+    %2 = bitcast <4 x float> %c to <4 x i32>
+    %or.i = or <4 x i32> %and.i, %2
+    %xor.i = xor <4 x i32> %or.i, %0
+    %3 = bitcast <4 x i32> %xor.i to <4 x float>
+    ret <4 x float> %3
+  }
+  
+  attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+  
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+  
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 2}
+  !4 = !{!"clang version 19.1.6 (git@github.com:wabka22/compiler-course-2025.git b1d11e23163ceba6c5fab91e30f0f2c49ac43d9f)"}
+
+...
+---
+# CHECK-LABEL:name: _Z24test_basic_and_operationDv4_fS_
+name:            _Z24test_basic_and_operationDv4_fS_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1
+
+    ; CHECK: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %2:vr128 = VPANDrr %1, %0
+    ; CHECK-NEXT: $xmm0 = COPY %2
+    ; CHECK-NEXT: RET 0, $xmm0
+  
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %2:vr128 = PANDrr %1, %0
+    $xmm0 = COPY %2
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL:name: _Z23test_basic_or_operationDv4_fS_
+name:            _Z23test_basic_or_operationDv4_fS_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1
+
+    ; CHECK: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %2:vr128 = VPORrr %1, %0
+    ; CHECK-NEXT: $xmm0 = COPY %2
+    ; CHECK-NEXT: RET 0, $xmm0
+  
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %2:vr128 = PORrr %1, %0
+    $xmm0 = COPY %2
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL:name: _Z24test_basic_xor_operationDv4_fS_
+name:            _Z24test_basic_xor_operationDv4_fS_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1
+
+    ; CHECK: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %2:vr128 = VPXORrr %1, %0
+    ; CHECK-NEXT: $xmm0 = COPY %2
+    ; CHECK-NEXT: RET 0, $xmm0
+  
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %2:vr128 = PXORrr %1, %0
+    $xmm0 = COPY %2
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL:name: _Z30test_combined_logic_operationsDv4_fS_S_
+name:            _Z30test_combined_logic_operationsDv4_fS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128, preferred-register: '' }
+  - { id: 1, class: vr128, preferred-register: '' }
+  - { id: 2, class: vr128, preferred-register: '' }
+  - { id: 3, class: vr128, preferred-register: '' }
+  - { id: 4, class: vr128, preferred-register: '' }
+  - { id: 5, class: vr128, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %3:vr128 = VPANDrr %1, %0
+    ; CHECK-NEXT: %4:vr128 = VPORrr %3, %2
+    ; CHECK-NEXT: %5:vr128 = VPXORrr %4, %0
+    ; CHECK-NEXT: $xmm0 = COPY %5
+    ; CHECK-NEXT: RET 0, $xmm0
+  
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = PANDrr %1, %0
+    %4:vr128 = PORrr %3, %2
+    %5:vr128 = PXORrr %4, %0
+    $xmm0 = COPY %5
+    RET 0, $xmm0

--- a/llvm/test/compiler-course/frolova_e_fma_tests/frolova_e_backend.mir
+++ b/llvm/test/compiler-course/frolova_e_fma_tests/frolova_e_backend.mir
@@ -1,0 +1,565 @@
+#  RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+avx \
+#  RUN:     --load=%llvmshlibdir/DecomposeFMAPass_Frolova_Elizaveta_FIIT3_BACKEND%shlibext \
+#  RUN:     -run-pass=fma-x86 %s -o - | FileCheck %s
+
+# Source File
+# test.cpp
+
+#include <immintrin.h>
+
+#// Test 1: Basic FMA-operation (a * b + c)
+#float test_fma_basic(float a, float b, float c) {
+#    return _mm_cvtss_f32(_mm_fmadd_ss(_mm_set_ss(a), _mm_set_ss(b), _mm_set_ss(c)));
+#}
+
+#// Test 2: FMA with same operand
+#float test_fma_same_reg(float a, float b) {
+#    return _mm_cvtss_f32(_mm_fmadd_ss(_mm_set_ss(a), _mm_set_ss(a), _mm_set_ss(b)));
+#}
+
+#// Test 3: No FMA
+#float test_no_fma(float a, float b, float c) {
+#    __m128 mul = _mm_mul_ss(_mm_set_ss(a), _mm_set_ss(b));
+#    return _mm_cvtss_f32(mul);
+#}
+
+#// Test 4: No FMA, but mul + add separately
+#float test_mul_add(float a, float b, float c) {
+#    __m128 mul = _mm_mul_ss(_mm_set_ss(a), _mm_set_ss(b));
+#    __m128 res = _mm_add_ss(mul, _mm_set_ss(c));
+#    return _mm_cvtss_f32(res);
+#}
+
+--- |
+  ; ModuleID = 'llvm/test/compiler-course/frolova_e_fma_tests/test.ll'
+  source_filename = "/home/liza/code/compiler-course-2025/llvm/test/compiler-course/frolova_e_fma_tests/test.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-unknown-linux-gnu"
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z17test_fma_basic132fff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
+  entry:
+    %0 = tail call float @llvm.fma.f32(float %a, float %b, float %c)
+    ret float %0
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z17test_fma_basic213fff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
+  entry:
+    %0 = tail call float @llvm.fma.f32(float %a, float %b, float %c)
+    ret float %0
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z17test_fma_basic231fff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
+  entry:
+    %0 = tail call float @llvm.fma.f32(float %a, float %b, float %c)
+    ret float %0
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z17test_fma_same_regff(float noundef %a, float noundef %b) local_unnamed_addr #0 {
+  entry:
+    %0 = tail call float @llvm.fma.f32(float %a, float %a, float %b)
+    ret float %0
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z11test_no_fmafff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
+  entry:
+    %mul.i = fmul float %a, %b
+    ret float %mul.i
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z12test_mul_addfff(float noundef %a, float noundef %b, float noundef %c) local_unnamed_addr #0 {
+  entry:
+    %mul.i = fmul float %a, %b
+    %add.i = fadd float %mul.i, %c
+    ret float %add.i
+  }
+  
+  ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+  declare float @llvm.fma.f32(float, float, float) #1
+  
+  attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+cmov,+crc32,+cx8,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave" "tune-cpu"="generic" }
+  attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+  
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+  
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 2}
+  !4 = !{!"clang version 19.1.6 (git@github.com:/ElizavetaFrolova/compiler-course-2025.git 294a518caccae62a31b81c6898596b1c74db4c98)"}
+
+...
+---
+# CHECK-LABEL: name:            _Z17test_fma_basic132fff
+name:            _Z17test_fma_basic132fff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ;CHECK: %2:fr32 = COPY $xmm2
+    ;CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %4:fr32 = VMULSSrr %1, %2, implicit $mxcsr
+    ;CHECK-NEXT: %3:fr32 = VADDSSrr %0, %4, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %3
+    ;CHECK-NEXT: RET 0, $xmm0
+  
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD132SSr %1, %0, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z17test_fma_basic213fff
+name:            _Z17test_fma_basic213fff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ;CHECK: %2:fr32 = COPY $xmm2
+    ;CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %4:fr32 = VMULSSrr %0, %1, implicit $mxcsr
+    ;CHECK-NEXT: %3:fr32 = VADDSSrr %2, %4, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %3
+    ;CHECK-NEXT: RET 0, $xmm0
+  
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD213SSr %1, %0, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z17test_fma_basic231fff
+name:            _Z17test_fma_basic231fff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ;CHECK: %2:fr32 = COPY $xmm2
+    ;CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %4:fr32 = VMULSSrr %0, %2, implicit $mxcsr
+    ;CHECK-NEXT: %3:fr32 = VADDSSrr %1, %4, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %3
+    ;CHECK-NEXT: RET 0, $xmm0
+  
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD231SSr %1, %0, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z17test_fma_same_regff 
+name:            _Z17test_fma_same_regff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1
+
+    ;CHECK: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %3:fr32 = VMULSSrr %0, %0, implicit $mxcsr
+    ;CHECK-NEXT: %2:fr32 = VADDSSrr %1, %3, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %2
+    ;CHECK-NEXT: RET 0, $xmm0
+  
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %2:fr32 = nofpexcept VFMADD213SSr %0, %0, %1, implicit $mxcsr
+    $xmm0 = COPY %2
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z11test_no_fmafff
+name:            _Z11test_no_fmafff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1
+
+    ;CHECK: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %3
+    ;CHECK-NEXT: RET 0, $xmm0
+  
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+# CHECK-LABEL: name:            _Z12test_mul_addfff
+name:            _Z12test_mul_addfff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+  - { id: 4, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+
+    ;CHECK: %2:fr32 = COPY $xmm2
+    ;CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ;CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ;CHECK-NEXT: %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    ;CHECK-NEXT: %4:fr32 = nofpexcept VADDSSrr killed %3, %2, implicit $mxcsr
+    ;CHECK-NEXT: $xmm0 = COPY %4
+    ;CHECK-NEXT: RET 0, $xmm0
+  
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    %4:fr32 = nofpexcept VADDSSrr killed %3, %2, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET 0, $xmm0
+
+...

--- a/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
+++ b/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
@@ -1,0 +1,73 @@
+# RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/FMAFlatten_Khovansky_Dmitry_FIIT2_BACKEND%shlibext \
+# RUN: -run-pass=FMA-flatten-x86  %s -o - | FileCheck %s
+
+--- |
+  ; ModuleID = 'FMAFlatten.c'
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+
+  declare <4 x float> @llvm.fma.v4f32(<4 x float>, <4 x float>, <4 x float>)
+  declare <2 x double> @llvm.fma.v2f64(<2 x double>, <2 x double>, <2 x double>)
+  declare float @llvm.fma.f32(float, float, float)
+  declare double @llvm.fma.f64(double, double, double)
+
+  define void @FMAFlatten(<4 x float> %a, <2 x double> %b, float %c, double %d) {
+    ret void
+  }
+...
+---
+name:            FMAFlatten
+body:             |
+  bb.0 (%ir-block.0):
+    liveins: $xmm0, $xmm1, $xmm2, $xmm3, $xmm4, $xmm5, $xmm6, $xmm7
+
+    ; 1. VFMADD132PSr (packed float)
+    ; CHECK:      [[MUL1:%[0-9]+]]:vr128 = MULPSrr %0, %0, implicit $mxcsr
+    ; CHECK-NEXT: %0:vr128 = ADDPSrr %0, [[MUL1]], implicit $mxcsr
+    %0:vr128 = COPY $xmm0
+    %0:vr128 = VFMADD132PSr %0, %0, %0, implicit $mxcsr
+
+    ; 2. VFMADD231PDr (packed double)
+    ; CHECK:      [[MUL2:%[0-9]+]]:vr128 = MULPDrr %1, %1, implicit $mxcsr
+    ; CHECK-NEXT: %1:vr128 = ADDPDrr %1, [[MUL2]], implicit $mxcsr
+    %1:vr128 = COPY $xmm1
+    %1:vr128 = VFMADD231PDr %1, %1, %1, implicit $mxcsr
+
+    ; 3. VFMADD213SSr (scalar float)
+    ; CHECK:      [[MUL3:%[0-9]+]]:fr32 = MULSSrr %2, %2, implicit $mxcsr
+    ; CHECK-NEXT: %2:fr32 = ADDSSrr %2, [[MUL3]], implicit $mxcsr
+    %2:fr32 = COPY $xmm2
+    %2:fr32 = VFMADD213SSr %2, %2, %2, implicit $mxcsr
+
+    ; 4. VFMADD132SDr (scalar double)
+    ; CHECK:      [[MUL4:%[0-9]+]]:fr64 = MULSDrr %3, %3, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr64 = ADDSDrr %3, [[MUL4]], implicit $mxcsr
+    %3:fr64 = COPY $xmm3
+    %3:fr64 = VFMADD132SDr %3, %3, %3, implicit $mxcsr
+
+    ; 5. VFMADD132PSr с разными регистрами
+    ; CHECK:      [[MUL5:%[0-9]+]]:vr128 = MULPSrr %4, %5, implicit $mxcsr
+    ; CHECK-NEXT: %6:vr128 = ADDPSrr %6, [[MUL5]], implicit $mxcsr
+    %4:vr128 = COPY $xmm4
+    %5:vr128 = COPY $xmm5
+    %6:vr128 = COPY $xmm6
+    %6:vr128 = VFMADD132PSr %4, %5, %6, implicit $mxcsr
+
+    ; 6. VFMADD213PDr с разными регистрами
+    ; CHECK:      [[MUL6:%[0-9]+]]:vr128 = MULPDrr %7, %5, implicit $mxcsr
+    ; CHECK-NEXT: %5:vr128 = ADDPDrr %5, [[MUL6]], implicit $mxcsr
+    %7:vr128 = COPY $xmm7
+    %5:vr128 = COPY $xmm5
+    %5:vr128 = VFMADD213PDr %7, %5, %5, implicit $mxcsr
+
+    ; 7. VFMADD231SSr с разными регистрами
+    ; CHECK:      [[MUL7:%[0-9]+]]:fr32 = MULSSrr %8, %2, implicit $mxcsr
+    ; CHECK-NEXT: %2:fr32 = ADDSSrr %2, [[MUL7]], implicit $mxcsr
+    %8:fr32 = COPY $xmm3
+    %2:fr32 = COPY $xmm2
+    %2:fr32 = VFMADD231SSr %8, %2, %2, implicit $mxcsr
+
+    ; Общая проверка
+    ; CHECK-NOT: VFMADD
+    RET 0
+

--- a/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
+++ b/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
@@ -53,14 +53,14 @@ body:             |
     %6:vr128 = COPY $xmm6
     %6:vr128 = VFMADD132PSr %4, %5, %6, implicit $mxcsr
 
-    ; 6. VFMADD213PDr с разными регистрами
+    ; 6. VFMADD213PDr с перекрытием регистров
     ; CHECK:      [[MUL6:%[0-9]+]]:vr128 = MULPDrr %7, %5, implicit $mxcsr
     ; CHECK-NEXT: %5:vr128 = ADDPDrr %5, [[MUL6]], implicit $mxcsr
     %7:vr128 = COPY $xmm7
     %5:vr128 = COPY $xmm5
     %5:vr128 = VFMADD213PDr %7, %5, %5, implicit $mxcsr
 
-    ; 7. VFMADD231SSr с разными регистрами
+    ; 7. VFMADD231SSr со смешанными типами данных
     ; CHECK:      [[MUL7:%[0-9]+]]:fr32 = MULSSrr %8, %2, implicit $mxcsr
     ; CHECK-NEXT: %2:fr32 = ADDSSrr %2, [[MUL7]], implicit $mxcsr
     %8:fr32 = COPY $xmm3

--- a/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
+++ b/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
@@ -14,65 +14,65 @@
   declare double @llvm.fma.f64(double, double, double)
 
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef float @_Z18test_132_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef float @_Z15test_132_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
     %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
     ret float %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef float @_Z18test_213_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef float @_Z15test_213_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
     %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
     ret float %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef float @_Z18test_231_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef float @_Z15test_231_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
     %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
     ret float %4
   }
 
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef double @_Z18test_132_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef double @_Z15test_132_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
     %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
     ret double %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef double @_Z18test_213_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef double @_Z15test_213_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
     %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
     ret double %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef double @_Z18test_231_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+  define dso_local noundef double @_Z15test_231_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
     %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
     ret double %4
   }
 
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <4 x float> @_Z7test_132_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <4 x float> @_Z11test_132_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
     ret <4 x float> %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <4 x float> @_Z7test_213_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <4 x float> @_Z11test_213_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
     ret <4 x float> %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <4 x float> @_Z7test_231_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <4 x float> @_Z11test_231_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
     ret <4 x float> %4
   }
 
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <2 x double> @_Z7test_132_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <2 x double> @_Z11test_132_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
     ret <2 x double> %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <2 x double> @_Z7test_213_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <2 x double> @_Z11test_213_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
     ret <2 x double> %4
   }
   ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
-  define dso_local noundef <2 x double> @_Z7test_231_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+  define dso_local noundef <2 x double> @_Z11test_231_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
     %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
     ret <2 x double> %4
   }
@@ -92,7 +92,7 @@
 
 ...
 ---
-name:            _Z18test_132_singlefff
+name:            _Z15test_132_singlefff
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -169,7 +169,7 @@ body:             |
 
 ...
 ---
-name:            _Z18test_213_singlefff
+name:            _Z15test_213_singlefff
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -246,7 +246,7 @@ body:             |
 
 ...
 ---
-name:            _Z18test_231_singlefff
+name:            _Z15test_231_singlefff
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -323,7 +323,7 @@ body:             |
 
 ...
 ---
-name:            _Z18test_132_doubleddd
+name:            _Z15test_132_doubleddd
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -400,7 +400,7 @@ body:             |
 
 ...
 ---
-name:            _Z18test_213_doubleddd
+name:            _Z15test_213_doubleddd
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -477,7 +477,7 @@ body:             |
 
 ...
 ---
-name:            _Z18test_231_doubleddd
+name:            _Z15test_231_doubleddd
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -554,7 +554,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_132_psDv4_fS_S_
+name:            _Z11test_132_psDv4_fS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -631,7 +631,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_213_psDv4_fS_S_
+name:            _Z11test_213_psDv4_fS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -708,7 +708,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_231_psDv4_fS_S_
+name:            _Z11test_231_psDv4_fS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -785,7 +785,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_132_pdDv2_dS_S_
+name:            _Z11test_132_pdDv2_dS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -862,7 +862,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_213_pdDv2_dS_S_
+name:            _Z11test_213_pdDv2_dS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false
@@ -939,7 +939,7 @@ body:             |
 
 ...
 ---
-name:            _Z7test_231_pdDv2_dS_S_
+name:            _Z11test_231_pdDv2_dS_S_
 alignment:       16
 exposesReturnsTwice: false
 legalized:       false

--- a/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
+++ b/llvm/test/compiler-course/khovansky_d_lab3/khovansky_d_lab3.mir
@@ -1,8 +1,10 @@
-# RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/FMAFlatten_Khovansky_Dmitry_FIIT2_BACKEND%shlibext \
-# RUN: -run-pass=FMA-flatten-x86  %s -o - | FileCheck %s
+# RUN: llc -mtriple x86_64-unknown-linux-gnu \
+# RUN:     --load=%llvmshlibdir/FMAFlatten_Khovansky_Dmitry_FIIT2_BACKEND%shlibext \
+# RUN:     -run-pass=FMA-flatten-x86 %s -o - | FileCheck %s
 
 --- |
-  ; ModuleID = 'FMAFlatten.c'
+  ; ModuleID = 'FMAFlatten.ll'
+  source_filename = "khovansky_d_lab3.cpp"
   target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
   target triple = "x86_64-pc-linux-gnu"
 
@@ -11,63 +13,1006 @@
   declare float @llvm.fma.f32(float, float, float)
   declare double @llvm.fma.f64(double, double, double)
 
-  define void @FMAFlatten(<4 x float> %a, <2 x double> %b, float %c, double %d) {
-    ret void
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z18test_132_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+    %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
+    ret float %4
   }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z18test_213_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+    %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
+    ret float %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef float @_Z18test_231_singlefff(float noundef %0, float noundef %1, float noundef %2) local_unnamed_addr #1 {
+    %4 = tail call float @llvm.fma.f32(float %0, float %1, float %2)
+    ret float %4
+  }
+
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef double @_Z18test_132_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+    %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
+    ret double %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef double @_Z18test_213_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+    %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
+    ret double %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef double @_Z18test_231_doubleddd(double noundef %0, double noundef %1, double noundef %2) local_unnamed_addr #1 {
+    %4 = tail call double @llvm.fma.f64(double %0, double %1, double %2)
+    ret double %4
+  }
+
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z7test_132_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
+    ret <4 x float> %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z7test_213_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
+    ret <4 x float> %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <4 x float> @_Z7test_231_psDv4_fS_S_(<4 x float> noundef %0, <4 x float> noundef %1, <4 x float> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <4 x float> @llvm.fma.v4f32(<4 x float> %0, <4 x float> %1, <4 x float> %2)
+    ret <4 x float> %4
+  }
+
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z7test_132_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
+    ret <2 x double> %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z7test_213_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
+    ret <2 x double> %4
+  }
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z7test_231_pdDv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call noundef <2 x double> @llvm.fma.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
+    ret <2 x double> %4
+  }
+
+  attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+cmov,+crc32,+cx8,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave" "tune-cpu"="generic" }
+  attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+avx,+cmov,+crc32,+cx8,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave" "tune-cpu"="generic" }
+  attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 2}
+  !4 = !{!"Ubuntu clang version 18.1.3 (1ubuntu1)"}
+
 ...
 ---
-name:            FMAFlatten
+name:            _Z18test_132_singlefff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
 body:             |
-  bb.0 (%ir-block.0):
-    liveins: $xmm0, $xmm1, $xmm2, $xmm3, $xmm4, $xmm5, $xmm6, $xmm7
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr32 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr32 = MULSSrr %0, %2, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr32 = ADDSSrr %1, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
 
-    ; 1. VFMADD132PSr (packed float)
-    ; CHECK:      [[MUL1:%[0-9]+]]:vr128 = MULPSrr %0, %0, implicit $mxcsr
-    ; CHECK-NEXT: %0:vr128 = ADDPSrr %0, [[MUL1]], implicit $mxcsr
-    %0:vr128 = COPY $xmm0
-    %0:vr128 = VFMADD132PSr %0, %0, %0, implicit $mxcsr
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD132SSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
 
-    ; 2. VFMADD231PDr (packed double)
-    ; CHECK:      [[MUL2:%[0-9]+]]:vr128 = MULPDrr %1, %1, implicit $mxcsr
-    ; CHECK-NEXT: %1:vr128 = ADDPDrr %1, [[MUL2]], implicit $mxcsr
+...
+---
+name:            _Z18test_213_singlefff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr32 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr32 = MULSSrr %1, %0, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr32 = ADDSSrr %2, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD213SSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z18test_231_singlefff
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32 }
+  - { id: 1, class: fr32 }
+  - { id: 2, class: fr32 }
+  - { id: 3, class: fr32 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr32 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr32 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr32 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr32 = MULSSrr %1, %2, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr32 = ADDSSrr %0, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:fr32 = COPY $xmm2
+    %1:fr32 = COPY $xmm1
+    %0:fr32 = COPY $xmm0
+    %3:fr32 = nofpexcept VFMADD231SSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z18test_132_doubleddd
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64 }
+  - { id: 1, class: fr64 }
+  - { id: 2, class: fr64 }
+  - { id: 3, class: fr64 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr64 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr64 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr64 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr64 = MULSDrr %0, %2, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr64 = ADDSDrr %1, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:fr64 = COPY $xmm2
+    %1:fr64 = COPY $xmm1
+    %0:fr64 = COPY $xmm0
+    %3:fr64 = nofpexcept VFMADD132SDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z18test_213_doubleddd
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64 }
+  - { id: 1, class: fr64 }
+  - { id: 2, class: fr64 }
+  - { id: 3, class: fr64 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr64 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr64 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr64 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr64 = MULSDrr %1, %0, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr64 = ADDSDrr %2, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:fr64 = COPY $xmm2
+    %1:fr64 = COPY $xmm1
+    %0:fr64 = COPY $xmm0
+    %3:fr64 = nofpexcept VFMADD213SDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z18test_231_doubleddd
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64 }
+  - { id: 1, class: fr64 }
+  - { id: 2, class: fr64 }
+  - { id: 3, class: fr64 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:fr64 = COPY $xmm2
+    ; CHECK-NEXT: %1:fr64 = COPY $xmm1
+    ; CHECK-NEXT: %0:fr64 = COPY $xmm0
+    ; CHECK-NEXT: %4:fr64 = MULSDrr %1, %2, implicit $mxcsr
+    ; CHECK-NEXT: %3:fr64 = ADDSDrr %0, %4, implicit $mxcsr
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:fr64 = COPY $xmm2
+    %1:fr64 = COPY $xmm1
+    %0:fr64 = COPY $xmm0
+    %3:fr64 = nofpexcept VFMADD231SDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z7test_132_psDv4_fS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPSrr %0, %2
+    ; CHECK-NEXT: %3:vr128 = ADDPSrr %1, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:vr128 = COPY $xmm2
     %1:vr128 = COPY $xmm1
-    %1:vr128 = VFMADD231PDr %1, %1, %1, implicit $mxcsr
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD132PSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
 
-    ; 3. VFMADD213SSr (scalar float)
-    ; CHECK:      [[MUL3:%[0-9]+]]:fr32 = MULSSrr %2, %2, implicit $mxcsr
-    ; CHECK-NEXT: %2:fr32 = ADDSSrr %2, [[MUL3]], implicit $mxcsr
-    %2:fr32 = COPY $xmm2
-    %2:fr32 = VFMADD213SSr %2, %2, %2, implicit $mxcsr
+...
+---
+name:            _Z7test_213_psDv4_fS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPSrr %1, %0
+    ; CHECK-NEXT: %3:vr128 = ADDPSrr %2, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
 
-    ; 4. VFMADD132SDr (scalar double)
-    ; CHECK:      [[MUL4:%[0-9]+]]:fr64 = MULSDrr %3, %3, implicit $mxcsr
-    ; CHECK-NEXT: %3:fr64 = ADDSDrr %3, [[MUL4]], implicit $mxcsr
-    %3:fr64 = COPY $xmm3
-    %3:fr64 = VFMADD132SDr %3, %3, %3, implicit $mxcsr
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD213PSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
 
-    ; 5. VFMADD132PSr с разными регистрами
-    ; CHECK:      [[MUL5:%[0-9]+]]:vr128 = MULPSrr %4, %5, implicit $mxcsr
-    ; CHECK-NEXT: %6:vr128 = ADDPSrr %6, [[MUL5]], implicit $mxcsr
-    %4:vr128 = COPY $xmm4
-    %5:vr128 = COPY $xmm5
-    %6:vr128 = COPY $xmm6
-    %6:vr128 = VFMADD132PSr %4, %5, %6, implicit $mxcsr
+...
+---
+name:            _Z7test_231_psDv4_fS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPSrr %1, %2
+    ; CHECK-NEXT: %3:vr128 = ADDPSrr %0, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
 
-    ; 6. VFMADD213PDr с перекрытием регистров
-    ; CHECK:      [[MUL6:%[0-9]+]]:vr128 = MULPDrr %7, %5, implicit $mxcsr
-    ; CHECK-NEXT: %5:vr128 = ADDPDrr %5, [[MUL6]], implicit $mxcsr
-    %7:vr128 = COPY $xmm7
-    %5:vr128 = COPY $xmm5
-    %5:vr128 = VFMADD213PDr %7, %5, %5, implicit $mxcsr
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD231PSr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
 
-    ; 7. VFMADD231SSr со смешанными типами данных
-    ; CHECK:      [[MUL7:%[0-9]+]]:fr32 = MULSSrr %8, %2, implicit $mxcsr
-    ; CHECK-NEXT: %2:fr32 = ADDSSrr %2, [[MUL7]], implicit $mxcsr
-    %8:fr32 = COPY $xmm3
-    %2:fr32 = COPY $xmm2
-    %2:fr32 = VFMADD231SSr %8, %2, %2, implicit $mxcsr
+...
+---
+name:            _Z7test_132_pdDv2_dS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPDrr %0, %2
+    ; CHECK-NEXT: %3:vr128 = ADDPDrr %1, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
 
-    ; Общая проверка
-    ; CHECK-NOT: VFMADD
-    RET 0
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD132PDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z7test_213_pdDv2_dS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPDrr %1, %0
+    ; CHECK-NEXT: %3:vr128 = ADDPDrr %2, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD213PDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
+---
+name:            _Z7test_231_pdDv2_dS_S_
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0:
+    liveins: $xmm0, $xmm1, $xmm2
+    ; CHECK: %2:vr128 = COPY $xmm2
+    ; CHECK-NEXT: %1:vr128 = COPY $xmm1
+    ; CHECK-NEXT: %0:vr128 = COPY $xmm0
+    ; CHECK-NEXT: %4:vr128 = MULPDrr %1, %2
+    ; CHECK-NEXT: %3:vr128 = ADDPDrr %0, %4
+    ; CHECK-NEXT: $xmm0 = COPY %3
+    ; CHECK-NEXT: RET 0, $xmm0
+
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept VFMADD231PDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %3
+    RET 0, $xmm0
+
+...
 

--- a/llvm/test/compiler-course/kozlova_e_lab3_var4_test/test_backend.mir
+++ b/llvm/test/compiler-course/kozlova_e_lab3_var4_test/test_backend.mir
@@ -1,0 +1,284 @@
+#  RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+fma \
+#  RUN:     --load=%llvmshlibdir/ExamplePass_Kozlova_Ekaterina_FIIT3_BACKEND%shlibext \
+#  RUN:     -run-pass=mul_sub %s -o - | FileCheck %s
+
+--- |
+  ; ModuleID = 'test.ll'
+  source_filename = "test.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+
+  module asm ".globl _ZSt21ios_base_library_initv"
+
+  %"class.std::basic_ostream" = type { ptr, %"class.std::basic_ios" }
+  %"class.std::basic_ios" = type { %"class.std::ios_base", ptr, i8, i8, ptr, ptr, ptr, ptr }
+  %"class.std::ios_base" = type { ptr, i64, i64, i32, i32, i32, ptr, %"struct.std::ios_base::_Words", [8 x %"struct.std::ios_base::_Words"], i32, ptr, %"class.std::locale" }
+  %"struct.std::ios_base::_Words" = type { ptr, i64 }
+  %"class.std::locale" = type { ptr }
+
+  @_ZSt4cout = external global %"class.std::basic_ostream", align 8
+
+  ; Function Attrs: noinline nounwind mustprogress uwtable
+  define dso_local float @test1(float %a, float %b, float %c) {
+  entry:
+    %mul = fmul float %a, %b
+    %sub = fsub float %c, %mul
+    ret float %sub
+  }
+
+  ; Function Attrs: noinline nounwind mustprogress uwtable
+  define dso_local noundef double @test2(double noundef %a, double noundef %b, double noundef %c) #0 {
+  entry:
+    %mul = fmul double %a, %b
+    %sub = fsub double %c, %mul
+    ret double %sub
+  }
+
+  ; Function Attrs: noinline nounwind mustprogress uwtable
+  define dso_local noundef double @test3(double noundef %a, double noundef %b, double noundef %c) #0 {
+  entry:
+    %mul = fmul double %b, %a
+    %sub = fsub double %c, %mul
+    ret double %sub
+  }
+
+
+  attributes #0 = { mustprogress noinline norecurse nounwind uwtable "frame-pointer"="non-leaf" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+fma,-avx" "tune-cpu"="x86-64-v3" }
+
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 2, !"Debug Info Version", i32 3}
+  !2 = !{i32 7, !"uwtable", i32 2}
+  !3 = !{i32 7, !"frame-pointer", i32 1}
+  !4 = !{!"Custom Clang"}
+
+...
+---
+
+# CHECK-LABEL: name: test1
+# CHECK: %[[RES:[0-9]+]]:fr32 = VFNMADD213SSr %2, %0, %1, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+name:            test1
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+  - { id: 4, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }  
+  - { reg: '$xmm1', virtual-reg: '%1' }  
+  - { reg: '$xmm2', virtual-reg: '%2' }  
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    %0:fr32 = COPY $xmm0  ; a
+    %1:fr32 = COPY $xmm1  ; b
+    %2:fr32 = COPY $xmm2  ; c
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr 
+    %4:fr32 = nofpexcept VSUBSSrr %2, killed %3, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+...
+---
+
+# CHECK-LABEL: name: test2
+# CHECK: %[[RES:[0-9]+]]:fr64 = VFNMADD213SDr %2, %0, %1, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+name:            test2
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64, preferred-register: '' }
+  - { id: 1, class: fr64, preferred-register: '' }
+  - { id: 2, class: fr64, preferred-register: '' }
+  - { id: 3, class: fr64, preferred-register: '' }
+  - { id: 4, class: fr64, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    %0:fr64 = COPY $xmm0  ; a
+    %1:fr64 = COPY $xmm1  ; b
+    %2:fr64 = COPY $xmm2  ; c
+    %3:fr64 = nofpexcept VMULSDrr %0, %1, implicit $mxcsr 
+    %4:fr64 = nofpexcept VSUBSDrr %2, killed %3, implicit $mxcsr 
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+...
+---
+
+# CHECK-LABEL: name: test3
+# CHECK: %[[RES:[0-9]+]]:fr64 = VFNMADD213SDr %2, %1, %0, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+name:            test3
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64, preferred-register: '' }
+  - { id: 1, class: fr64, preferred-register: '' }
+  - { id: 2, class: fr64, preferred-register: '' }
+  - { id: 3, class: fr64, preferred-register: '' }
+  - { id: 4, class: fr64, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    %0:fr64 = COPY $xmm0  ; a
+    %1:fr64 = COPY $xmm1  ; b
+    %2:fr64 = COPY $xmm2  ; c
+    %3:fr64 = nofpexcept VMULSDrr %1, %0, implicit $mxcsr 
+    %4:fr64 = nofpexcept VSUBSDrr %2, killed %3, implicit $mxcsr 
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0

--- a/llvm/test/compiler-course/lavrentyevBackendTest/lavrentyev-backend-lit.mir
+++ b/llvm/test/compiler-course/lavrentyevBackendTest/lavrentyev-backend-lit.mir
@@ -1,0 +1,420 @@
+#  RUN: llc -mattr=+fma \
+#  RUN:     --load=%llvmshlibdir/FMSUBComposePass_Lavrentyev_Alexey_FIIT3_BACKEND%shlibext \
+#  RUN:     -run-pass=fmsub-compose-x86 %s -o - | FileCheck %s
+
+--- |
+  ; ModuleID = 'tests.ll'
+  source_filename = "test.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite) uwtable
+  define dso_local void @testPackedPS(ptr nocapture noundef %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2) local_unnamed_addr #0 {
+    %4 = load float, ptr %1, align 4, !tbaa !5
+    %5 = load float, ptr %2, align 4, !tbaa !5
+    %6 = fmul float %4, %5
+    %7 = load float, ptr %0, align 4, !tbaa !5
+    %8 = fsub float %7, %6
+    store float %8, ptr %0, align 4, !tbaa !5
+    ret void
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite) uwtable
+  define dso_local void @testPackedPD(ptr nocapture noundef %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2) local_unnamed_addr #0 {
+    %4 = load double, ptr %1, align 8, !tbaa !9
+    %5 = load double, ptr %2, align 8, !tbaa !9
+    %6 = fmul double %4, %5
+    %7 = load double, ptr %0, align 8, !tbaa !9
+    %8 = fsub double %7, %6
+    store double %8, ptr %0, align 8, !tbaa !9
+    ret void
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite) uwtable
+  define dso_local void @testScalarSS(ptr nocapture noundef %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2) local_unnamed_addr #0 {
+    %4 = load float, ptr %1, align 4, !tbaa !5
+    %5 = load float, ptr %2, align 4, !tbaa !5
+    %6 = fmul float %4, %5
+    %7 = load float, ptr %0, align 4, !tbaa !5
+    %8 = fsub float %7, %6
+    store float %8, ptr %0, align 4, !tbaa !5
+    ret void
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite) uwtable
+  define dso_local void @testScalarSD(ptr nocapture noundef %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2) local_unnamed_addr #0 {
+    %4 = load double, ptr %1, align 8, !tbaa !9
+    %5 = load double, ptr %2, align 8, !tbaa !9
+    %6 = fmul double %4, %5
+    %7 = load double, ptr %0, align 8, !tbaa !9
+    %8 = fsub double %7, %6
+    store double %8, ptr %0, align 8, !tbaa !9
+    ret void
+  }
+  
+  attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite) uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87,-avx" "tune-cpu"="generic" }
+  
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+  
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 2}
+  !4 = !{!"Ubuntu clang version 18.1.3 (1ubuntu1)"}
+  !5 = !{!6, !6, i64 0}
+  !6 = !{!"float", !7, i64 0}
+  !7 = !{!"omnipotent char", !8, i64 0}
+  !8 = !{!"Simple C++ TBAA"}
+  !9 = !{!10, !10, i64 0}
+  !10 = !{!"double", !7, i64 0}
+
+...
+---
+
+# CHECK-LABEL: name: testPackedPS
+# CHECK: %2:gr64 = COPY $rdx
+# CHECK-NEXT: %1:gr64 = COPY $rsi
+# CHECK-NEXT: %0:gr64 = COPY $rdi
+# CHECK-NEXT: %3:fr32 = MOVSSrm_alt %1, 1, $noreg, 0, $noreg :: (load (s32) from %ir.1, !tbaa !5)
+# CHECK-NEXT: %6:fr32 = VFMSUB213SSm %2, %5, implicit $mxcsr :: (load (s32) from %ir.2, !tbaa !5)
+# CHECK-NEXT: %5:fr32 = MOVSSrm_alt %0, 1, $noreg, 0, $noreg :: (load (s32) from %ir.0, !tbaa !5)
+# CHECK-NEXT: MOVSSmr %0, 1, $noreg, 0, $noreg, killed %6 :: (store (s32) into %ir.0, !tbaa !5)
+# CHECK-NEXT: RET 0
+
+name:            testPackedPS
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr64, preferred-register: '' }
+  - { id: 1, class: gr64, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+  - { id: 4, class: fr32, preferred-register: '' }
+  - { id: 5, class: fr32, preferred-register: '' }
+  - { id: 6, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$rdi', virtual-reg: '%0' }
+  - { reg: '$rsi', virtual-reg: '%1' }
+  - { reg: '$rdx', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $rdi, $rsi, $rdx
+  
+    %2:gr64 = COPY $rdx
+    %1:gr64 = COPY $rsi
+    %0:gr64 = COPY $rdi
+    %3:fr32 = MOVSSrm_alt %1, 1, $noreg, 0, $noreg :: (load (s32) from %ir.1, !tbaa !5)
+    %4:fr32 = nofpexcept MULSSrm %3, %2, 1, $noreg, 0, $noreg, implicit $mxcsr :: (load (s32) from %ir.2, !tbaa !5)
+    %5:fr32 = MOVSSrm_alt %0, 1, $noreg, 0, $noreg :: (load (s32) from %ir.0, !tbaa !5)
+    %6:fr32 = nofpexcept SUBSSrr %5, killed %4, implicit $mxcsr
+    MOVSSmr %0, 1, $noreg, 0, $noreg, killed %6 :: (store (s32) into %ir.0, !tbaa !5)
+    RET 0
+
+...
+---
+
+# CHECK-LABEL: name: testPackedPD
+# CHECK: %2:gr64 = COPY $rdx
+# CHECK-NEXT: %1:gr64 = COPY $rsi
+# CHECK-NEXT: %0:gr64 = COPY $rdi
+# CHECK-NEXT: %3:fr64 = MOVSDrm_alt %1, 1, $noreg, 0, $noreg :: (load (s64) from %ir.1, !tbaa !9)
+# CHECK-NEXT: %6:fr64 = VFMSUB213SDm %2, %5, implicit $mxcsr :: (load (s64) from %ir.2, !tbaa !9)
+# CHECK-NEXT: %5:fr64 = MOVSDrm_alt %0, 1, $noreg, 0, $noreg :: (load (s64) from %ir.0, !tbaa !9)
+# CHECK-NEXT: MOVSDmr %0, 1, $noreg, 0, $noreg, killed %6 :: (store (s64) into %ir.0, !tbaa !9)
+# CHECK-NEXT: RET 0
+
+name:            testPackedPD
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr64, preferred-register: '' }
+  - { id: 1, class: gr64, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: fr64, preferred-register: '' }
+  - { id: 4, class: fr64, preferred-register: '' }
+  - { id: 5, class: fr64, preferred-register: '' }
+  - { id: 6, class: fr64, preferred-register: '' }
+liveins:
+  - { reg: '$rdi', virtual-reg: '%0' }
+  - { reg: '$rsi', virtual-reg: '%1' }
+  - { reg: '$rdx', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $rdi, $rsi, $rdx
+  
+    %2:gr64 = COPY $rdx
+    %1:gr64 = COPY $rsi
+    %0:gr64 = COPY $rdi
+    %3:fr64 = MOVSDrm_alt %1, 1, $noreg, 0, $noreg :: (load (s64) from %ir.1, !tbaa !9)
+    %4:fr64 = nofpexcept MULSDrm %3, %2, 1, $noreg, 0, $noreg, implicit $mxcsr :: (load (s64) from %ir.2, !tbaa !9)
+    %5:fr64 = MOVSDrm_alt %0, 1, $noreg, 0, $noreg :: (load (s64) from %ir.0, !tbaa !9)
+    %6:fr64 = nofpexcept SUBSDrr %5, killed %4, implicit $mxcsr
+    MOVSDmr %0, 1, $noreg, 0, $noreg, killed %6 :: (store (s64) into %ir.0, !tbaa !9)
+    RET 0
+
+...
+---
+
+# CHECK-LABEL: name: testScalarSS
+# CHECK: %2:gr64 = COPY $rdx
+# CHECK-NEXT: %1:gr64 = COPY $rsi
+# CHECK-NEXT: %0:gr64 = COPY $rdi
+# CHECK-NEXT: %3:fr32 = MOVSSrm_alt %1, 1, $noreg, 0, $noreg :: (load (s32) from %ir.1, !tbaa !5)
+# CHECK-NEXT: %6:fr32 = VFMSUB213SSm %2, %5, implicit $mxcsr :: (load (s32) from %ir.2, !tbaa !5)
+# CHECK-NEXT: %5:fr32 = MOVSSrm_alt %0, 1, $noreg, 0, $noreg :: (load (s32) from %ir.0, !tbaa !5)
+# CHECK-NEXT: MOVSSmr %0, 1, $noreg, 0, $noreg, killed %6 :: (store (s32) into %ir.0, !tbaa !5)
+# CHECK-NEXT: RET 0
+
+name:            testScalarSS
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr64, preferred-register: '' }
+  - { id: 1, class: gr64, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+  - { id: 4, class: fr32, preferred-register: '' }
+  - { id: 5, class: fr32, preferred-register: '' }
+  - { id: 6, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$rdi', virtual-reg: '%0' }
+  - { reg: '$rsi', virtual-reg: '%1' }
+  - { reg: '$rdx', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $rdi, $rsi, $rdx
+  
+    %2:gr64 = COPY $rdx
+    %1:gr64 = COPY $rsi
+    %0:gr64 = COPY $rdi
+    %3:fr32 = MOVSSrm_alt %1, 1, $noreg, 0, $noreg :: (load (s32) from %ir.1, !tbaa !5)
+    %4:fr32 = nofpexcept MULSSrm %3, %2, 1, $noreg, 0, $noreg, implicit $mxcsr :: (load (s32) from %ir.2, !tbaa !5)
+    %5:fr32 = MOVSSrm_alt %0, 1, $noreg, 0, $noreg :: (load (s32) from %ir.0, !tbaa !5)
+    %6:fr32 = nofpexcept SUBSSrr %5, killed %4, implicit $mxcsr
+    MOVSSmr %0, 1, $noreg, 0, $noreg, killed %6 :: (store (s32) into %ir.0, !tbaa !5)
+    RET 0
+
+...
+---
+
+# CHECK-LABEL: name: testScalarSD
+# CHECK: %2:gr64 = COPY $rdx
+# CHECK-NEXT: %1:gr64 = COPY $rsi
+# CHECK-NEXT: %0:gr64 = COPY $rdi
+# CHECK-NEXT: %3:fr64 = MOVSDrm_alt %1, 1, $noreg, 0, $noreg :: (load (s64) from %ir.1, !tbaa !9)
+# CHECK-NEXT: %6:fr64 = VFMSUB213SDm %2, %5, implicit $mxcsr :: (load (s64) from %ir.2, !tbaa !9)
+# CHECK-NEXT: %5:fr64 = MOVSDrm_alt %0, 1, $noreg, 0, $noreg :: (load (s64) from %ir.0, !tbaa !9)
+# CHECK-NEXT: MOVSDmr %0, 1, $noreg, 0, $noreg, killed %6 :: (store (s64) into %ir.0, !tbaa !9)
+# CHECK-NEXT: RET 0
+
+name:            testScalarSD
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: gr64, preferred-register: '' }
+  - { id: 1, class: gr64, preferred-register: '' }
+  - { id: 2, class: gr64, preferred-register: '' }
+  - { id: 3, class: fr64, preferred-register: '' }
+  - { id: 4, class: fr64, preferred-register: '' }
+  - { id: 5, class: fr64, preferred-register: '' }
+  - { id: 6, class: fr64, preferred-register: '' }
+liveins:
+  - { reg: '$rdi', virtual-reg: '%0' }
+  - { reg: '$rsi', virtual-reg: '%1' }
+  - { reg: '$rdx', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $rdi, $rsi, $rdx
+  
+    %2:gr64 = COPY $rdx
+    %1:gr64 = COPY $rsi
+    %0:gr64 = COPY $rdi
+    %3:fr64 = MOVSDrm_alt %1, 1, $noreg, 0, $noreg :: (load (s64) from %ir.1, !tbaa !9)
+    %4:fr64 = nofpexcept MULSDrm %3, %2, 1, $noreg, 0, $noreg, implicit $mxcsr :: (load (s64) from %ir.2, !tbaa !9)
+    %5:fr64 = MOVSDrm_alt %0, 1, $noreg, 0, $noreg :: (load (s64) from %ir.0, !tbaa !9)
+    %6:fr64 = nofpexcept SUBSDrr %5, killed %4, implicit $mxcsr
+    MOVSDmr %0, 1, $noreg, 0, $noreg, killed %6 :: (store (s64) into %ir.0, !tbaa !9)
+    RET 0
+
+...

--- a/llvm/test/compiler-course/solovev_a_test_3/test_backend.mir
+++ b/llvm/test/compiler-course/solovev_a_test_3/test_backend.mir
@@ -1,0 +1,286 @@
+#  RUN: llc -mtriple=x86_64-unknown-linux-gnu -mattr=+fma \
+#  RUN:     --load=%llvmshlibdir/Lab_3_backend_Solovev_a_FIIT1_BACKEND%shlibext \
+#  RUN:     -run-pass=mul_sub_solovev %s -o - | FileCheck %s
+
+--- |
+  ; ModuleID = 'mulsub_test_solovev_a.ll'
+  source_filename = "mulsub_test_solovev_a.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+
+  module asm ".globl _ZSt21ios_base_library_initv"
+
+  %"class.std::basic_ostream" = type { ptr, %"class.std::basic_ios" }
+  %"class.std::basic_ios" = type { %"class.std::ios_base", ptr, i8, i8, ptr, ptr, ptr, ptr }
+  %"class.std::ios_base" = type { ptr, i64, i64, i32, i32, i32, ptr, %"struct.std::ios_base::_Words", [8 x %"struct.std::ios_base::_Words"], i32, ptr, %"class.std::locale" }
+  %"struct.std::ios_base::_Words" = type { ptr, i64 }
+  %"class.std::locale" = type { ptr }
+
+  @_ZSt4cout = external global %"class.std::basic_ostream", align 8
+
+  ; Function Attrs: noinline nounwind mustprogress uwtable
+  define dso_local float @test_solovev_float(float %x, float %y, float %acc) {
+  entry:
+    %mul = fmul float %x, %y
+    %acc_val = fsub float %acc, %mul
+    ret float %acc_val
+  }
+
+  ; Function Attrs: noinline nounwind mustprogress uwtable
+  define dso_local noundef double @test_solovev_double(double noundef %x, double noundef %y, double noundef %acc) #0 {
+  entry:
+    %mul = fmul double %x, %y
+    %acc_val = fsub double %acc, %mul
+    ret double %acc_val
+  }
+
+  ; Function Attrs: noinline nounwind mustprogress uwtable
+  define dso_local noundef double @test_solovev_double_change_vals(double noundef %x, double noundef %y, double noundef %acc) #0 {
+  entry:
+    %mul = fmul double %y, %x
+    %acc_val = fsub double %acc, %mul
+    ret double %acc_val
+  }
+
+
+  attributes #0 = { mustprogress noinline norecurse nounwind uwtable "frame-pointer"="non-leaf" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+fma,-avx" "tune-cpu"="x86-64-v3" }
+
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 2, !"Debug Info Version", i32 3}
+  !2 = !{i32 7, !"uwtable", i32 2}
+  !3 = !{i32 7, !"frame-pointer", i32 1}
+  !4 = !{!"Solovev LLVM Custom v1.0"}
+
+...
+---
+
+# CHECK-LABEL: name: test_solovev_float
+# CHECK: %[[RES:[0-9]+]]:fr32 = VFNMADD213SSr %2, %0, %1, 0, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+name:            test_solovev_float
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr32, preferred-register: '' }
+  - { id: 1, class: fr32, preferred-register: '' }
+  - { id: 2, class: fr32, preferred-register: '' }
+  - { id: 3, class: fr32, preferred-register: '' }
+  - { id: 4, class: fr32, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }  
+  - { reg: '$xmm1', virtual-reg: '%1' }  
+  - { reg: '$xmm2', virtual-reg: '%2' }  
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    %0:fr32 = COPY $xmm0  ; x
+    %1:fr32 = COPY $xmm1  ; y
+    %2:fr32 = COPY $xmm2  ; acc
+    %3:fr32 = nofpexcept VMULSSrr %0, %1, implicit $mxcsr
+    %4:fr32 = nofpexcept VSUBSSrr %2, killed %3, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+
+...
+---
+
+# CHECK-LABEL: name: test_solovev_double
+# CHECK: %[[RES:[0-9]+]]:fr64 = VFNMADD213SDr %2, %0, %1, 0, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+name:            test_solovev_double
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64, preferred-register: '' }
+  - { id: 1, class: fr64, preferred-register: '' }
+  - { id: 2, class: fr64, preferred-register: '' }
+  - { id: 3, class: fr64, preferred-register: '' }
+  - { id: 4, class: fr64, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    %0:fr64 = COPY $xmm0  ; x
+    %1:fr64 = COPY $xmm1  ; y
+    %2:fr64 = COPY $xmm2  ; acc
+    %3:fr64 = nofpexcept VMULSDrr %0, %1, implicit $mxcsr
+    %4:fr64 = nofpexcept VSUBSDrr %2, killed %3, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0
+
+...
+---
+
+# CHECK-LABEL: name: test_solovev_double_change_vals
+# CHECK: %[[RES:[0-9]+]]:fr64 = VFNMADD213SDr %2, %1, %0, 0, implicit $mxcsr, implicit $mxcsr
+# CHECK: $xmm0 = COPY %[[RES]]
+# CHECK: RET64 implicit $xmm0
+
+name:            test_solovev_double_change_vals
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   false
+failsVerification: false
+tracksDebugUserValues: false
+registers:
+  - { id: 0, class: fr64, preferred-register: '' }
+  - { id: 1, class: fr64, preferred-register: '' }
+  - { id: 2, class: fr64, preferred-register: '' }
+  - { id: 3, class: fr64, preferred-register: '' }
+  - { id: 4, class: fr64, preferred-register: '' }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  amxProgModel:    None
+body:             |
+  bb.0.entry:
+    liveins: $xmm0, $xmm1, $xmm2
+    %0:fr64 = COPY $xmm0  ; x
+    %1:fr64 = COPY $xmm1  ; y
+    %2:fr64 = COPY $xmm2  ; acc
+    %3:fr64 = nofpexcept VMULSDrr %1, %0, implicit $mxcsr
+    %4:fr64 = nofpexcept VSUBSDrr %2, killed %3, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET64 implicit $xmm0

--- a/mlir/compiler-course/lopatinLowerRemPass/CMakeLists.txt
+++ b/mlir/compiler-course/lopatinLowerRemPass/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(Title "LowerRemPass")
+set(Student "IlyaLopatin")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_MLIR")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+
+add_llvm_pass_plugin(${TARGET_NAME}
+    ${SOURCES}
+    DEPENDS
+    intrinsics_gen
+    MLIRBuiltinLocationAttributesIncGen
+    BUILDTREE_ONLY
+)
+
+set(MLIR_TEST_DEPENDS ${TARGET_NAME} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/compiler-course/lopatinLowerRemPass/lowerRemPass.cpp
+++ b/mlir/compiler-course/lopatinLowerRemPass/lowerRemPass.cpp
@@ -1,0 +1,63 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+namespace {
+// rem(a,b) -> a - (a // b) * b
+template <typename RemOp, typename DivOp>
+struct GenericRemLowering : public OpRewritePattern<RemOp> {
+  GenericRemLowering(MLIRContext *context) : OpRewritePattern<RemOp>(context) {}
+  LogicalResult matchAndRewrite(RemOp op,
+                                PatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    Value a = op.getOperand(0);
+    Value b = op.getOperand(1);
+    auto divOp = rewriter.create<DivOp>(loc, a, b);
+    Value quo = divOp.getResult();
+    auto mulOp = rewriter.create<arith::MulIOp>(loc, quo, b);
+    auto subOp = rewriter.create<arith::SubIOp>(loc, a, mulOp.getResult());
+    rewriter.replaceOp(op, subOp.getResult());
+    return success();
+  }
+};
+
+using RemSIOpLowering = GenericRemLowering<arith::RemSIOp, arith::DivSIOp>;
+using RemUIOpLowering = GenericRemLowering<arith::RemUIOp, arith::DivUIOp>;
+
+struct LowerRemPass
+    : public PassWrapper<LowerRemPass, OperationPass<ModuleOp>> {
+  StringRef getArgument() const final {
+    return "LowerRemPass_IlyaLopatin_FIIT3_MLIR";
+  }
+  StringRef getDescription() const final {
+    return "Lower arith.remsi/remui into a - (a // b) * b";
+  }
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect>();
+  }
+  void runOnOperation() override {
+    MLIRContext &ctx = getContext();
+    RewritePatternSet patterns(&ctx);
+    patterns.add<RemSIOpLowering, RemUIOpLowering>(&ctx);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(LowerRemPass)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(LowerRemPass)
+
+mlir::PassPluginLibraryInfo getLowerRemPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "LowerRemPass", "1.0",
+          []() { mlir::PassRegistration<LowerRemPass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getLowerRemPassPluginInfo();
+}

--- a/mlir/test/compiler-course/lopatinLoweringRemTest/testRemLit.mlir
+++ b/mlir/test/compiler-course/lopatinLoweringRemTest/testRemLit.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/LowerRemPass_IlyaLopatin_FIIT3_MLIR%shlibext \
+// RUN: --pass-pipeline="builtin.module(LowerRemPass_IlyaLopatin_FIIT3_MLIR)" %s | FileCheck %s
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i128, dense<128> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>, #dlti.dl_entry<"dlti.endianness", "little">>} {
+  // CHECK-LABEL: @test_signed_rem
+  // CHECK-NEXT:     %0 = arith.divsi %arg0, %arg1 : i32
+  // CHECK-NEXT:     %1 = arith.muli %0, %arg1 : i32
+  // CHECK-NEXT:     %2 = arith.subi %arg0, %1 : i32
+  // CHECK-NEXT:     llvm.return %2 : i32
+  // CHECK-NEXT:   }
+  llvm.func local_unnamed_addr @test_signed_rem(%arg0: i32 {llvm.noundef}, %arg1: i32 {llvm.noundef}) -> (i32 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic", will_return} {
+    %0 = arith.remsi %arg0, %arg1  : i32
+    llvm.return %0 : i32
+  }
+
+  // CHECK-LABEL: @test_unsigned_rem
+  // CHECK-NEXT:     %0 = arith.divui %arg0, %arg1 : i32
+  // CHECK-NEXT:     %1 = arith.muli %0, %arg1 : i32
+  // CHECK-NEXT:     %2 = arith.subi %arg0, %1 : i32
+  // CHECK-NEXT:     llvm.return %2 : i32
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  llvm.func local_unnamed_addr @test_unsigned_rem(%arg0: i32 {llvm.noundef}, %arg1: i32 {llvm.noundef}) -> (i32 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic", will_return} {
+    %0 = arith.remui %arg0, %arg1  : i32
+    llvm.return %0 : i32
+  }
+}


### PR DESCRIPTION
Пасс FMAFlatten осуществляет разложение FMA-инструкций (Fused Multiply-Add) в эквивалентную последовательность из двух отдельных машинных инструкций: умножения и последующего сложения. Он обходит все базовые блоки в функции и для каждой инструкции проверяет, относится ли она к семейству VFMADD. При обнаружении такой инструкции определяется соответствие между её типом и подходящими операциями MUL и ADD. Далее создаётся временный виртуальный регистр для хранения промежуточного результата умножения, после чего в поток инструкций вставляются две новые команды: сначала MUL, затем ADD, которая завершает вычисление. Оригинальная FMA-инструкция после этого удаляется. Пасс поддерживает как скалярные, так и векторные типы данных одинарной и двойной точности (SS, SD, PS, PD).